### PR TITLE
fix(vpx): keep alpha channels for rgba bmp

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -215,8 +215,10 @@ fn biff_tags_and_hashes(reader: &mut BiffReader) -> Vec<(String, usize, usize, u
             }
             "BITS" => {
                 let data = reader.data_until("ALTV".as_bytes());
-                // Looks like vpinball encodes de lzw stream in a slightly different way.
+                // Looks like vpinball encodes de lzw stream in a slightly different way. Ending
+                // up with the same compressed size but different compressed data.
                 // However, vpinball can also read the standard lzw stream we write.
+                // So for these images we look at the raw data hash.
                 let decompressed = from_lzw_blocks(&data);
                 let hash = hash_data(&decompressed);
                 tags.push((

--- a/tests/vpx_read_extract_assemble_write_compare_all.rs
+++ b/tests/vpx_read_extract_assemble_write_compare_all.rs
@@ -29,6 +29,7 @@ mod test {
         // * Johnny Mnemonic (Williams 1995) VPW v1.0.2.vpx - animated frames that overlap with primitive names
         // * Future Spa (Bally 1979) v4.3.vpx - NaN in table setup values
         // * InvaderTable_2.260.vpx - Symbol fonts
+        // * Guns N Roses (Data East 1994).vpx - contains BMP with non-255 alpha values
         let filtered: Vec<&PathBuf> = paths
             .iter()
             // .filter(|path| {


### PR DESCRIPTION
Continuation of #69 