### PR TITLE
Add table ini filepath from vpx path

### DIFF
--- a/src/vpx/mod.rs
+++ b/src/vpx/mod.rs
@@ -488,6 +488,11 @@ pub fn vbs_path_for(vpx_file_path: &PathBuf) -> PathBuf {
     path_for(vpx_file_path, "vbs")
 }
 
+/// Returns the path to table `ini` file
+pub fn ini_path_for(vpx_file_path: &PathBuf) -> PathBuf {
+    path_for(vpx_file_path, "ini")
+}
+
 fn path_for(vpx_file_path: &PathBuf, extension: &str) -> PathBuf {
     PathBuf::from(vpx_file_path).with_extension(extension)
 }


### PR DESCRIPTION
This PR adds a function to retrieve a table `.ini` file from its `.vpx` file location.

I added this functionality for my [ini edition PR on vpxtool](https://github.com/francisdb/vpxtool/pull/487).