### PR TITLE
chore: reduce image size warning logs

### DIFF
--- a/src/vpx/expanded.rs
+++ b/src/vpx/expanded.rs
@@ -277,18 +277,16 @@ fn write_images<P: AsRef<Path>>(vpx: &VPX, expanded_dir: &P) -> Result<(), Write
                 let dimensions_file = read_image_dimensions_from_file_steam(&file_name, cursor)?;
                 match dimensions_file {
                     Some((width_file, height_file)) => {
-                        if image.width != width_file {
+                        if image.width != width_file || image.height != height_file {
                             eprintln!(
-                                "Image width override for {} in vpx ({}) vs in image ({})",
-                                file_name, image.width, width_file
+                                "Image dimension override for {} in vpx {}x{} vs in image {}x{}",
+                                file_name, image.width, image.height, width_file, height_file
                             );
+                        }
+                        if image.width != width_file {
                             json.width = Some(image.width);
                         }
                         if image.height != height_file {
-                            eprintln!(
-                                "Image height override for {} in vpx ({}) vs in image ({})",
-                                file_name, image.height, height_file
-                            );
                             json.height = Some(image.height);
                         }
                     }
@@ -464,11 +462,11 @@ fn read_images<P: AsRef<Path>>(expanded_dir: &P) -> io::Result<Vec<ImageData>> {
 
                         let width = match image_data_json.width {
                             Some(w) => {
-                                if let Some(dimensions) = dimensions_from_file {
-                                    if w != dimensions.0 {
+                                if let Some((image_w,_)) = dimensions_from_file {
+                                    if w != image_w {
                                         eprintln!(
                                             "Image width override for {} in json ({}) vs in image ({})",
-                                            full_file_name, w, dimensions.0
+                                            full_file_name, w, image_w
                                         );
                                     }
                                 }
@@ -483,11 +481,11 @@ fn read_images<P: AsRef<Path>>(expanded_dir: &P) -> io::Result<Vec<ImageData>> {
 
                         let height = match image_data_json.height {
                             Some(h) => {
-                                if let Some(dimensions) = dimensions_from_file {
-                                    if h != dimensions.1 {
+                                if let Some((_,image_h)) = dimensions_from_file {
+                                    if h != image_h {
                                         eprintln!(
                                             "Image height override for {} in json ({}) vs in image ({})",
-                                            full_file_name, h, dimensions.1
+                                            full_file_name, h, image_h
                                         );
                                     }
                                 }

--- a/src/vpx/font.rs
+++ b/src/vpx/font.rs
@@ -48,7 +48,7 @@ impl fmt::Debug for FontData {
 impl FontData {
     pub(crate) fn ext(&self) -> String {
         // TODO we might want to also check the jpeg fsPath
-        match self.path.split('.').last() {
+        match self.path.split('.').next_back() {
             Some(ext) => ext.to_string(),
             None => "bin".to_string(),
         }

--- a/src/vpx/image.rs
+++ b/src/vpx/image.rs
@@ -98,7 +98,7 @@ impl ImageData {
 
     pub fn ext(&self) -> String {
         // TODO we might want to also check the jpeg fsPath
-        match self.path.split('.').last() {
+        match self.path.split('.').next_back() {
             Some(ext) => ext.to_string(),
             None => "bin".to_string(),
         }
@@ -227,7 +227,7 @@ impl ImageDataJson {
 
     pub(crate) fn ext(&self) -> String {
         // TODO we might want to also check the jpeg fsPath
-        match self.path.split('.').last() {
+        match self.path.split('.').next_back() {
             Some(ext) => ext.to_string(),
             None => "bin".to_string(),
         }

--- a/src/vpx/sound.rs
+++ b/src/vpx/sound.rs
@@ -297,7 +297,7 @@ impl Default for WaveForm {
 impl SoundData {
     pub(crate) fn ext(&self) -> String {
         // TODO we might want to also check the jpeg fsPath
-        match self.path.split('.').last() {
+        match self.path.split('.').next_back() {
             Some(ext) => ext.to_string(),
             None => "bin".to_string(),
         }

--- a/tests/vpx_read_extract_assemble_write_compare_all.rs
+++ b/tests/vpx_read_extract_assemble_write_compare_all.rs
@@ -30,12 +30,20 @@ mod test {
         // * Future Spa (Bally 1979) v4.3.vpx - NaN in table setup values
         // * InvaderTable_2.260.vpx - Symbol fonts
         // * Guns N Roses (Data East 1994).vpx - contains BMP with non-255 alpha values
+        // * Affected by https://github.com/vpinball/vpinball/pull/2286
+        //    - CAPTAINSPAULDINGv1.0.vpx - contains boolean value that is not 0 or 1
+        //    - RM054.vpx (Rick & Morty Wip)
+        // * TODO something with the M3CX
+        //    - Stranger Things 4 LPE 1.0 (Limited PRO Edition).vpx something with the M3CX
+        //    - Stranger Things 4 Premium.vpx also has problems with the M3CX
         let filtered: Vec<&PathBuf> = paths
             .iter()
-            // .filter(|path| {
-            //     let name = path.file_name().unwrap().to_str().unwrap();
-            //     name.contains("Bob")
-            // })
+            .filter(|path| {
+                let name = path.file_name().unwrap().to_str().unwrap();
+                !name.contains("CAPTAINSPAULDINGv1.0")
+                    && !name.contains("RM054")
+                    && !name.contains("Stranger Things 4")
+            })
             .collect();
 
         // TODO why is par_iter() not faster but just consuming all cpu cores?


### PR DESCRIPTION
Also excludes some vpx files that are currently failing the tests