### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
Potential fix for [https://github.com/francisdb/vpin/security/code-scanning/2](https://github.com/francisdb/vpin/security/code-scanning/2)

The best fix is to explicitly set the `permissions` block in the workflow yaml file. Since the workflow only builds and tests code, and does not interact with issues, pull requests, or need to write to repository contents, the minimal permission required is `contents: read`. You should add a `permissions:` entry at the workflow root (above `jobs:`), which will apply to all jobs by default. This change is localized and does not alter existing functionality.

**Steps:**
- In `.github/workflows/rust.yml`, add the following block after the workflow `name` and before or after the `on:` block (but before `jobs:`):
  ```yaml
  permissions:
    contents: read
  ```
- No other changes or imports are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
