### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,4 +1,6 @@
 name: Clippy check
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/francisdb/vpin/security/code-scanning/1](https://github.com/francisdb/vpin/security/code-scanning/1)

To minimize the privileges for the `GITHUB_TOKEN` in the workflow, add a `permissions:` block specifying the minimum required access. Since all current steps are read-only (checking out code, caching dependencies, installing toolchains, running lints/formatting), the least privilege necessary is `contents: read`. The `permissions` block can be set at the root of the workflow file, so it applies to all jobs. You should add, right after the `name:` field and before `on:`, a new block:

```yaml
permissions:
  contents: read
```

No other changes are required since all current steps only need read access to the repository contents; they do not require write access to issues, pull-requests, or other resources.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
