### PR TITLE
misc: improve image dimensions warning

### DIFF
--- a/src/vpx/expanded.rs
+++ b/src/vpx/expanded.rs
@@ -640,7 +640,6 @@ fn read_images<P: AsRef<Path>>(expanded_dir: &P) -> io::Result<Vec<ImageData>> {
                             );
                         }
 
-
                         let mut image = image_data_json.to_image_data(width, height, None);
                         if let Some(jpg) = &mut image.jpeg {
                             jpg.data = image_data;


### PR DESCRIPTION
fixes #177

```
[2025-12-31T11:08:24Z INFO  vpin::vpx::expanded] Stale image dimensions for apron.webp in vpx 3072x3072 vs in image 3584x3584
...
[2025-12-31T11:08:26Z WARN  vpin::vpx::expanded] Stale image dimensions for apron.webp in json 3072x3072 vs in image 3584x3584
```
