### PR TITLE
chore: release v0.20.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.5](https://github.com/francisdb/vpin/compare/v0.20.4...v0.20.5) - 2026-01-20
+
+### Other
+
+- update README with links to npm package
+- allow triggering further workflow runs
+
 ## [0.20.4](https://github.com/francisdb/vpin/compare/v0.20.3...v0.20.4) - 2026-01-20
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vpin"
-version = "0.20.4"
+version = "0.20.5"
 edition = "2024"
 description = "Rust library for the virtual pinball ecosystem"
 repository = "https://github.com/francisdb/vpin"


### PR DESCRIPTION



## 🤖 New release

* `vpin`: 0.20.4 -> 0.20.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.20.5](https://github.com/francisdb/vpin/compare/v0.20.4...v0.20.5) - 2026-01-20

### Other

- update README with links to npm package
- allow triggering further workflow runs
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).