### PR TITLE
chore: release v0.20.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.7](https://github.com/francisdb/vpin/compare/v0.20.6...v0.20.7) - 2026-01-20
+
+### Other
+
+- update npm package references
+
 ## [0.20.6](https://github.com/francisdb/vpin/compare/v0.20.5...v0.20.6) - 2026-01-20
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vpin"
-version = "0.20.6"
+version = "0.20.7"
 edition = "2024"
 description = "Rust library for the virtual pinball ecosystem"
 repository = "https://github.com/francisdb/vpin"


### PR DESCRIPTION



## 🤖 New release

* `vpin`: 0.20.6 -> 0.20.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.20.7](https://github.com/francisdb/vpin/compare/v0.20.6...v0.20.7) - 2026-01-20

### Other

- update npm package references
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).