### PR TITLE
chore: release v0.20.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.9](https://github.com/francisdb/vpin/compare/v0.20.8...v0.20.9) - 2026-01-23
+
+### Added
+
+- directb2s cargo feature and update documentation ([#207](https://github.com/francisdb/vpin/pull/207))
+- switch to f32 precision in OBJ file handling ([#206](https://github.com/francisdb/vpin/pull/206))
+
+### Other
+
+- vertex compression and add tracing instrumentation ([#204](https://github.com/francisdb/vpin/pull/204))
+- *(deps)* update quick-xml requirement from 0.38.4 to 0.39.0 ([#187](https://github.com/francisdb/vpin/pull/187))
+- set cfb buffer sizes ([#193](https://github.com/francisdb/vpin/pull/193))
+
 ## [0.20.8](https://github.com/francisdb/vpin/compare/v0.20.7...v0.20.8) - 2026-01-20
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vpin"
-version = "0.20.8"
+version = "0.20.9"
 edition = "2024"
 description = "Rust library for the virtual pinball ecosystem"
 repository = "https://github.com/francisdb/vpin"


### PR DESCRIPTION



## 🤖 New release

* `vpin`: 0.20.8 -> 0.20.9

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.20.9](https://github.com/francisdb/vpin/compare/v0.20.8...v0.20.9) - 2026-01-23

### Added

- directb2s cargo feature and update documentation ([#207](https://github.com/francisdb/vpin/pull/207))
- switch to f32 precision in OBJ file handling ([#206](https://github.com/francisdb/vpin/pull/206))

### Other

- vertex compression and add tracing instrumentation ([#204](https://github.com/francisdb/vpin/pull/204))
- *(deps)* update quick-xml requirement from 0.38.4 to 0.39.0 ([#187](https://github.com/francisdb/vpin/pull/187))
- set cfb buffer sizes ([#193](https://github.com/francisdb/vpin/pull/193))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).