### PR TITLE
deps: switch flate2 dependency to use zlib-rs feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ web-sys = { version = "0.3", optional = true, features = ["console"] }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 # Use zlib-ng for much faster compression/decompression on native targets
-flate2 = { version = "1.1.8", features = ["zlib-ng"], default-features = false }
+flate2 = { version = "1.1.8", features = ["zlib-rs"], default-features = false }
 image = { version = "0.25.9", default-features = false, features = [
     "bmp", "exr", "gif", "hdr", "jpeg", "png", "tga", "webp", "rayon"
 ] }


### PR DESCRIPTION
zlib-ng requires native compilation and zlib-rs is faster than miniz_oxide albeit uses unsafe code

https://github.com/rust-lang/flate2-rs?tab=readme-ov-file#backends