### PR TITLE
chore: release v0.20.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.10](https://github.com/francisdb/vpin/compare/v0.20.9...v0.20.10) - 2026-01-28
+
+### Other
+
+- switch flate2 dependency to use zlib-rs feature ([#209](https://github.com/francisdb/vpin/pull/209))
+
 ## [0.20.9](https://github.com/francisdb/vpin/compare/v0.20.8...v0.20.9) - 2026-01-28
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vpin"
-version = "0.20.9"
+version = "0.20.10"
 edition = "2024"
 description = "Rust library for the virtual pinball ecosystem"
 repository = "https://github.com/francisdb/vpin"


### PR DESCRIPTION



## 🤖 New release

* `vpin`: 0.20.9 -> 0.20.10

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.20.10](https://github.com/francisdb/vpin/compare/v0.20.9...v0.20.10) - 2026-01-28

### Other

- switch flate2 dependency to use zlib-rs feature ([#209](https://github.com/francisdb/vpin/pull/209))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).