### PR TITLE
chore: release v0.20.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.11](https://github.com/francisdb/vpin/compare/v0.20.10...v0.20.11) - 2026-01-29
+
+### Added
+
+- improve directory listing ([#213](https://github.com/francisdb/vpin/pull/213))
+
+### Other
+
+- split up expanded module ([#211](https://github.com/francisdb/vpin/pull/211))
+
 ## [0.20.10](https://github.com/francisdb/vpin/compare/v0.20.9...v0.20.10) - 2026-01-28
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vpin"
-version = "0.20.10"
+version = "0.20.11"
 edition = "2024"
 description = "Rust library for the virtual pinball ecosystem"
 repository = "https://github.com/francisdb/vpin"


### PR DESCRIPTION



## 🤖 New release

* `vpin`: 0.20.10 -> 0.20.11

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.20.11](https://github.com/francisdb/vpin/compare/v0.20.10...v0.20.11) - 2026-01-29

### Added

- improve directory listing ([#213](https://github.com/francisdb/vpin/pull/213))

### Other

- split up expanded module ([#211](https://github.com/francisdb/vpin/pull/211))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).