### PR TITLE
chore: release v0.20.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.12](https://github.com/francisdb/vpin/compare/v0.20.11...v0.20.12) - 2026-02-06
+
+### Fixed
+
+- warn for invalid bool ([#220](https://github.com/francisdb/vpin/pull/220))
+- *(json)* correct type fields from type_ to type ([#218](https://github.com/francisdb/vpin/pull/218))
+
 ## [0.20.11](https://github.com/francisdb/vpin/compare/v0.20.10...v0.20.11) - 2026-01-29
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vpin"
-version = "0.20.11"
+version = "0.20.12"
 edition = "2024"
 description = "Rust library for the virtual pinball ecosystem"
 repository = "https://github.com/francisdb/vpin"


### PR DESCRIPTION



## 🤖 New release

* `vpin`: 0.20.11 -> 0.20.12

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.20.12](https://github.com/francisdb/vpin/compare/v0.20.11...v0.20.12) - 2026-02-06

### Fixed

- warn for invalid bool ([#220](https://github.com/francisdb/vpin/pull/220))
- *(json)* correct type fields from type_ to type ([#218](https://github.com/francisdb/vpin/pull/218))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).