### PR TITLE
chore: release v0.20.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.13](https://github.com/francisdb/vpin/compare/v0.20.12...v0.20.13) - 2026-02-06
+
+### Fixed
+
+- correct playfield reflection strength quantization ([#222](https://github.com/francisdb/vpin/pull/222))
+
 ## [0.20.12](https://github.com/francisdb/vpin/compare/v0.20.11...v0.20.12) - 2026-02-06
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vpin"
-version = "0.20.12"
+version = "0.20.13"
 edition = "2024"
 description = "Rust library for the virtual pinball ecosystem"
 repository = "https://github.com/francisdb/vpin"


### PR DESCRIPTION



## 🤖 New release

* `vpin`: 0.20.12 -> 0.20.13

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.20.13](https://github.com/francisdb/vpin/compare/v0.20.12...v0.20.13) - 2026-02-06

### Fixed

- correct playfield reflection strength quantization ([#222](https://github.com/francisdb/vpin/pull/222))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).