### PR TITLE
chore: release v0.20.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.15](https://github.com/francisdb/vpin/compare/v0.20.14...v0.20.15) - 2026-02-06
+
+### Other
+
+- log warn instead of tracing warn
+
 ## [0.20.14](https://github.com/francisdb/vpin/compare/v0.20.13...v0.20.14) - 2026-02-06
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vpin"
-version = "0.20.14"
+version = "0.20.15"
 edition = "2024"
 description = "Rust library for working with Visual Pinball VPX files"
 repository = "https://github.com/francisdb/vpin"


### PR DESCRIPTION



## 🤖 New release

* `vpin`: 0.20.14 -> 0.20.15

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.20.15](https://github.com/francisdb/vpin/compare/v0.20.14...v0.20.15) - 2026-02-06

### Other

- log warn instead of tracing warn
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).