### PR TITLE
chore: release v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0](https://github.com/francisdb/vpin/compare/v0.20.15...v0.21.0) - 2026-02-14
+
+### Added
+
+- [**breaking**] force major version bump after adding mesh generation
+- convert vpx to glb (gltf) ([#231](https://github.com/francisdb/vpin/pull/231))
+- add GLTF format support for mesh extraction and reading ([#229](https://github.com/francisdb/vpin/pull/229))
+
+### Other
+
+- add missing ignores on integration test ([#243](https://github.com/francisdb/vpin/pull/243))
+- cfb 0.14.0 ([#242](https://github.com/francisdb/vpin/pull/242))
+
 ## [0.20.15](https://github.com/francisdb/vpin/compare/v0.20.14...v0.20.15) - 2026-02-06
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vpin"
-version = "0.20.15"
+version = "0.21.0"
 edition = "2024"
 description = "Rust library for working with Visual Pinball VPX files"
 repository = "https://github.com/francisdb/vpin"


### PR DESCRIPTION



## 🤖 New release

* `vpin`: 0.20.15 -> 0.21.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.21.0](https://github.com/francisdb/vpin/compare/v0.20.15...v0.21.0) - 2026-02-14

### Added

- [**breaking**] force major version bump after adding mesh generation
- convert vpx to glb (gltf) ([#231](https://github.com/francisdb/vpin/pull/231))
- add GLTF format support for mesh extraction and reading ([#229](https://github.com/francisdb/vpin/pull/229))

### Other

- add missing ignores on integration test ([#243](https://github.com/francisdb/vpin/pull/243))
- cfb 0.14.0 ([#242](https://github.com/francisdb/vpin/pull/242))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).