### PR TITLE
test: add missing ignores on integration test

### DIFF
--- a/src/vpx/mod.rs
+++ b/src/vpx/mod.rs
@@ -404,7 +404,9 @@ fn write_vpx<F: Read + Write + Seek>(comp: &mut CompoundFile<F>, vpx: &VPX) -> i
     write_collections(comp, &vpx.collections)?;
     debug!("Wrote {} collections", vpx.collections.len());
     let mac = generate_mac(comp)?;
-    write_mac(comp, &mac)
+    write_mac(comp, &mac)?;
+    info!("Wrote VPX");
+    Ok(())
 }
 
 /// Writes a minimal `vpx` file

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -16,6 +16,37 @@ use vpin::vpx::biff::BiffReader;
 use vpin::vpx::lzw::from_lzw_blocks;
 use walkdir::WalkDir;
 
+pub(crate) fn init_logger() {
+    use crate::common::tracing_duration_filter::DurationFilterLayer;
+    use std::time::Duration;
+    use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
+
+    // let _ = env_logger::builder()
+    //     .is_test(true)
+    //     .filter_level(log::LevelFilter::Info)
+    //     .try_init();
+
+    // let _ = fmt()
+    //     .with_env_filter(
+    //         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+    //     )
+    //     .with_test_writer()
+    //     .with_span_events(fmt::format::FmtSpan::CLOSE)
+    //     .try_init();
+
+    let _ = tracing_subscriber::registry()
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
+        .with(
+            fmt::layer()
+                .with_test_writer()
+                // Enable colored output
+                .with_ansi(true), // Show timing when spans close
+                                  //.with_span_events(fmt::format::FmtSpan::CLOSE),
+        )
+        .with(DurationFilterLayer::new(Duration::from_millis(300)))
+        .try_init();
+}
+
 /// if TABLES_DIR is set use that
 /// otherwise use ~/vpinball/tables
 pub(crate) fn tables_dir() -> PathBuf {

--- a/tests/vpx_read_extract_assemble_write_compare_all.rs
+++ b/tests/vpx_read_extract_assemble_write_compare_all.rs
@@ -10,7 +10,7 @@ mod test {
     use pretty_assertions::assert_eq;
     // TODO once we can capture logs per extract / assemble we can re-enable parallel tests
     // use rayon::prelude::*;
-    use crate::common::{assert_equal_vpx, find_files, tables_dir};
+    use crate::common::{assert_equal_vpx, find_files, init_logger, tables_dir};
     use log::info;
     use std::io;
     use std::path::{Path, PathBuf};
@@ -18,41 +18,10 @@ mod test {
     use vpin::filesystem::{FileSystem, MemoryFileSystem, RealFileSystem};
     use vpin::vpx::expanded::{ExpandOptions, PrimitiveMeshFormat};
 
-    fn init() {
-        use crate::common::tracing_duration_filter::DurationFilterLayer;
-        use std::time::Duration;
-        use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
-
-        // let _ = env_logger::builder()
-        //     .is_test(true)
-        //     .filter_level(log::LevelFilter::Info)
-        //     .try_init();
-
-        // let _ = fmt()
-        //     .with_env_filter(
-        //         EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-        //     )
-        //     .with_test_writer()
-        //     .with_span_events(fmt::format::FmtSpan::CLOSE)
-        //     .try_init();
-
-        let _ = tracing_subscriber::registry()
-            .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")))
-            .with(
-                fmt::layer()
-                    .with_test_writer()
-                    // Enable colored output
-                    .with_ansi(true), // Show timing when spans close
-                                      //.with_span_events(fmt::format::FmtSpan::CLOSE),
-            )
-            .with(DurationFilterLayer::new(Duration::from_millis(300)))
-            .try_init();
-    }
-
     #[test]
     #[ignore = "slow integration test that only runs on correctly set up machines"]
     fn read_extract_assemble_and_write_all() -> io::Result<()> {
-        init();
+        init_logger();
         let folder = tables_dir();
         let paths = find_files(&folder, "vpx")?;
         // testdir can not be used in non-main threads

--- a/tests/vpx_read_write_compare_all.rs
+++ b/tests/vpx_read_write_compare_all.rs
@@ -3,12 +3,11 @@ mod common;
 #[cfg(test)]
 #[cfg(not(target_family = "wasm"))]
 mod test {
-
-    // use pretty_assertions::assert_eq;
-    // use rayon::prelude::*;
-    use crate::common::{assert_equal_vpx, find_files, tables_dir};
+    use crate::common::{assert_equal_vpx, find_files, init_logger, tables_dir};
+    use log::info;
     use std::io;
-    use std::path::{Path, PathBuf};
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use testdir::testdir;
     use testresult::TestResult;
 
@@ -31,38 +30,39 @@ mod test {
     #[test]
     #[ignore = "slow integration test that only runs on correctly set up machines"]
     fn read_and_write_all() -> io::Result<()> {
+        init_logger();
         let folder = tables_dir();
         let paths = find_files(&folder, "vpx")?;
-        // testdir can not be used in non-main threads
-        let dir: PathBuf = testdir!();
-        // TODO why is par_iter() not faster but just consuming all cpu cores?
-        paths
-            .iter()
-            // .filter(|p| {
-            //     p.file_name()
-            //         .unwrap()
-            //         .to_string_lossy()
-            //         .to_ascii_lowercase()
-            //         .contains("diehard")
-            // })
-            .try_for_each(|vpx_path| {
-                println!("testing: {vpx_path:?}");
-                let test_vpx_path = read_and_write_vpx(&dir, vpx_path)?;
-                let vpx_bytes = std::fs::read(vpx_path)?;
-                let test_vpx_bytes = std::fs::read(&test_vpx_path)?;
-                assert_equal_vpx(&vpx_bytes, &test_vpx_bytes, vpx_path);
-                // if all is good we remove the test file
-                std::fs::remove_file(&test_vpx_path)?;
-                Ok(())
-            })
-    }
 
-    fn read_and_write_vpx(dir: &Path, path: &Path) -> io::Result<PathBuf> {
-        let original = vpin::vpx::read(path)?;
-        // create temp file and write the vpx to it
-        let file_name = path.file_name().unwrap();
-        let test_vpx_path = dir.join(file_name);
-        vpin::vpx::write(&test_vpx_path, &original)?;
-        Ok(test_vpx_path)
+        // Example tables caused problems in the past:
+        //
+        // * Affected by https://github.com/vpinball/vpinball/pull/2286
+        //    - CAPTAINSPAULDINGv1.0.vpx - contains boolean value that is not 0 or 1
+        //    - RM054.vpx (Rick & Morty Wip)
+        // * invalid bools and out of sync materials
+        //    - Ghostbusters LE_4_1 - VLM - VLM - VLM2 - VLM4 - VLM.vpx
+        let filtered: Vec<&PathBuf> = paths
+            .iter()
+            .filter(|path| {
+                let name = path.file_name().unwrap().to_str().unwrap();
+                !name.contains("CAPTAINSPAULDINGv1.0")
+                    && !name.contains("RM054")
+                    && !name.contains("Ghostbusters LE_4_1 - VLM - VLM - VLM2 - VLM4 - VLM")
+            })
+            .collect();
+        let counter = AtomicUsize::new(0);
+        let total = filtered.len();
+        // To run this superfast but no error output
+        // use rayon::prelude::*;
+        // filtered.par_iter().try_for_each(|vpx_path| {
+        filtered.iter().try_for_each(|vpx_path| {
+            let n = counter.fetch_add(1, Ordering::Relaxed) + 1;
+            info!("testing {}/{}: {:?}", n, total, vpx_path);
+            let vpx_bytes = std::fs::read(vpx_path)?;
+            let original = vpin::vpx::from_bytes(&vpx_bytes)?;
+            let test_vpx_bytes = vpin::vpx::to_bytes(&original)?;
+            assert_equal_vpx(&vpx_bytes, &test_vpx_bytes, vpx_path);
+            Ok(())
+        })
     }
 }


### PR DESCRIPTION
fixes #241 

* makes tests faster (or super fast if you uncomment the rayon part)
* add missing ignores that were already set up on the other test