### PR TITLE
chore: release v0.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.1](https://github.com/francisdb/vpin/compare/v0.21.0...v0.21.1) - 2026-02-16
+
+### Added
+
+- part group order warnings ([#249](https://github.com/francisdb/vpin/pull/249))
+
+### Fixed
+
+- update DILI handling to use quantization ([#246](https://github.com/francisdb/vpin/pull/246))
+
 ## [0.21.0](https://github.com/francisdb/vpin/compare/v0.20.15...v0.21.0) - 2026-02-14
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vpin"
-version = "0.21.0"
+version = "0.21.1"
 edition = "2024"
 description = "Rust library for working with Visual Pinball VPX files"
 repository = "https://github.com/francisdb/vpin"


### PR DESCRIPTION



## 🤖 New release

* `vpin`: 0.21.0 -> 0.21.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.21.1](https://github.com/francisdb/vpin/compare/v0.21.0...v0.21.1) - 2026-02-16

### Added

- part group order warnings ([#249](https://github.com/francisdb/vpin/pull/249))

### Fixed

- update DILI handling to use quantization ([#246](https://github.com/francisdb/vpin/pull/246))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).