### PR TITLE
chore: release v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0](https://github.com/francisdb/vpin/compare/v0.23.6...v0.24.0) - 2026-05-04
+
+### Added
+
+- *(vpx)* add VpxFile gamedata write + lock helpers ([#287](https://github.com/francisdb/vpin/pull/287))
+
+### Other
+
+- *(vpx)* [**breaking**] drop VpxFile::toggle_lock ([#289](https://github.com/francisdb/vpin/pull/289))
+
 ## [0.23.6](https://github.com/francisdb/vpin/compare/v0.23.5...v0.23.6) - 2026-05-03
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vpin"
-version = "0.23.6"
+version = "0.24.0"
 edition = "2024"
 description = "Rust library for working with Visual Pinball VPX files"
 repository = "https://github.com/francisdb/vpin"


### PR DESCRIPTION



## 🤖 New release

* `vpin`: 0.23.6 -> 0.24.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.24.0](https://github.com/francisdb/vpin/compare/v0.23.6...v0.24.0) - 2026-05-04

### Added

- *(vpx)* add VpxFile gamedata write + lock helpers ([#287](https://github.com/francisdb/vpin/pull/287))

### Other

- *(vpx)* [**breaking**] drop VpxFile::toggle_lock ([#289](https://github.com/francisdb/vpin/pull/289))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).