### PR TITLE
chore: release v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0](https://github.com/francisdb/vpin/compare/v0.24.0...v0.25.0) - 2026-05-06
+
+### Added
+
+- *(vpx)* [**breaking**] match vpinball OBJ format and accept Blender-style input ([#293](https://github.com/francisdb/vpin/pull/293))
+
+### Other
+
+- add crates.io, docs.rs and npm badges to README ([#291](https://github.com/francisdb/vpin/pull/291))
+- depend on published wavefront-obj-io crate ([#290](https://github.com/francisdb/vpin/pull/290))
+
 ## [0.24.0](https://github.com/francisdb/vpin/compare/v0.23.6...v0.24.0) - 2026-05-04
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vpin"
-version = "0.24.0"
+version = "0.25.0"
 edition = "2024"
 description = "Rust library for working with Visual Pinball VPX files"
 repository = "https://github.com/francisdb/vpin"


### PR DESCRIPTION



## 🤖 New release

* `vpin`: 0.24.0 -> 0.25.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.25.0](https://github.com/francisdb/vpin/compare/v0.24.0...v0.25.0) - 2026-05-06

### Added

- *(vpx)* [**breaking**] match vpinball OBJ format and accept Blender-style input ([#293](https://github.com/francisdb/vpin/pull/293))

### Other

- add crates.io, docs.rs and npm badges to README ([#291](https://github.com/francisdb/vpin/pull/291))
- depend on published wavefront-obj-io crate ([#290](https://github.com/francisdb/vpin/pull/290))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).