### PR TITLE
feat(wasm): add obj_to_mesh / mesh_to_obj typed-array API

### DIFF
--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -34,7 +34,11 @@ jobs:
         run: cargo build --release --target wasm32-unknown-unknown --features wasm --no-default-features
 
       - name: Generate bindings
-        run: wasm-bindgen --target web --out-dir pkg target/wasm32-unknown-unknown/release/vpin.wasm
+        # `--weak-refs` registers Rust-owned wasm-bindgen objects with the
+        # JS `FinalizationRegistry`, so memory is reclaimed automatically
+        # when the JS wrapper is garbage-collected. Removes the need for
+        # callers to call `.free()` manually.
+        run: wasm-bindgen --target web --weak-refs --out-dir pkg target/wasm32-unknown-unknown/release/vpin.wasm
 
       - name: Update package version
         run: |

--- a/src/vpx/mod.rs
+++ b/src/vpx/mod.rs
@@ -73,7 +73,7 @@ pub(crate) mod json;
 pub mod export;
 mod gltf;
 pub mod lzw;
-mod mesh;
+pub(crate) mod mesh;
 pub(crate) mod obj;
 pub(crate) mod wav;
 

--- a/src/vpx/mod.rs
+++ b/src/vpx/mod.rs
@@ -74,7 +74,7 @@ pub mod export;
 mod gltf;
 pub mod lzw;
 mod mesh;
-mod obj;
+pub(crate) mod obj;
 pub(crate) mod wav;
 
 /// In-memory representation of a VPX file

--- a/src/vpx/obj.rs
+++ b/src/vpx/obj.rs
@@ -154,14 +154,33 @@ pub(crate) struct ReadObjResult {
     pub(crate) vpx_encoded_vertices: BytesMut,
 }
 
-pub(crate) fn read_obj_from_reader<R: BufRead>(mut reader: &mut R) -> io::Result<ReadObjResult> {
+pub(crate) fn read_obj_from_reader<R: BufRead>(reader: &mut R) -> io::Result<ReadObjResult> {
+    read_obj_from_reader_with_options(reader, true)
+}
+
+/// Like [`read_obj_from_reader`] but lets the caller pick whether
+/// vpinball's right-handed -> left-handed conversion should be applied
+/// (Z negate on positions and normals, V flip on texture coordinates,
+/// per-triangle corner reverse). Mirrors vpinball's
+/// `ObjLoader::Load`'s `convertToLeftHanded` flag.
+///
+/// `convert_to_left_handed = true` matches the existing assemble path
+/// (input is in vpinball's exported convention - i.e. the same form
+/// `extract` writes - and we convert to vpx-internal coordinates).
+/// `false` skips the conversion: the input is assumed to already be in
+/// vpx-internal convention so its values pass through unchanged.
+pub(crate) fn read_obj_from_reader_with_options<R: BufRead>(
+    mut reader: &mut R,
+    convert_to_left_handed: bool,
+) -> io::Result<ReadObjResult> {
     let ObjData {
         name,
         vertices,
         texture_coordinates,
         normals,
         indices,
-    } = read_obj(&mut reader).map_err(|e| io::Error::other(format!("Error reading obj: {}", e)))?;
+    } = read_obj_with_options(&mut reader, convert_to_left_handed)
+        .map_err(|e| io::Error::other(format!("Error reading obj: {}", e)))?;
 
     let mut final_vertices = Vec::with_capacity(vertices.len());
     let mut vpx_encoded_vertices = BytesMut::with_capacity(vertices.len() * 32);
@@ -170,21 +189,24 @@ pub(crate) fn read_obj_from_reader<R: BufRead>(mut reader: &mut R) -> io::Result
         .zip(texture_coordinates.iter())
         .zip(normals.iter())
     {
-        let nx = vn.x;
-        let ny = vn.y;
-        let nz = -vn.z;
+        // vpinball's ObjLoader::Load (with `convertToLeftHanded=true`)
+        // negates Z on vertices and normals and flips V on texcoords.
+        // With the flag false those transforms are skipped.
+        let (z, nz, tv) = if convert_to_left_handed {
+            (-v.2, -vn.z, 1.0 - vt.1.unwrap_or(0.0))
+        } else {
+            (v.2, vn.z, vt.1.unwrap_or(0.0))
+        };
 
         let vertext = Vertex3dNoTex2 {
             x: v.0,
             y: v.1,
-            z: -v.2,
-            nx,
-            ny,
+            z,
+            nx: vn.x,
+            ny: vn.y,
             nz,
             tu: vt.0,
-            // vpinball's ObjLoader::Load (with flipTv=true) inverts the
-            // V flip applied on write.
-            tv: 1.0 - vt.1.unwrap_or(0.0),
+            tv,
         };
         write_vertex(&mut vpx_encoded_vertices, &vertext, &vn.vpx_bytes);
         final_vertices.push(vertext);
@@ -285,16 +307,16 @@ impl VpxObjReader {
     ///
     /// If every face is a vpinball-format triangle (3 corners with matching
     /// `v/vt/vn`), the v/vt/vn arrays are returned as-is and the indices
-    /// list is built directly with the per-triangle reverse that mirrors
-    /// vpinball's `WriteFaceInfoLong`.
+    /// list is built directly. With `reverse_corners=true` the per-triangle
+    /// corner order is reversed to undo vpinball's `WriteFaceInfoLong`
+    /// reversal; with `false` the source winding is preserved.
     ///
     /// Otherwise (Blender-style n-gons or mismatched corners), the
-    /// [`triangulate_and_dedup`] step runs over the collected data with
-    /// `reverse_corners=true`: faces are corner-reversed, fan-triangulated
-    /// and `(pos, uv, normal)` corners are deduplicated. The v/vt/vn arrays
-    /// are rebuilt to be aligned (same length, one entry per combined
-    /// corner).
-    fn read<R: io::Read>(mut self, reader: &mut R) -> io::Result<ObjData> {
+    /// [`triangulate_and_dedup`] step runs over the collected data; the
+    /// same `reverse_corners` flag controls whether faces are reversed
+    /// before fan-triangulation. The v/vt/vn arrays are rebuilt to be
+    /// aligned (same length, one entry per combined corner).
+    fn read<R: io::Read>(mut self, reader: &mut R, reverse_corners: bool) -> io::Result<ObjData> {
         wavefront_obj_io::read_obj_file(reader, &mut self)?;
         if self.object_count != 1 {
             return Err(io::Error::new(
@@ -312,7 +334,7 @@ impl VpxObjReader {
                 self.vertices.len(),
                 self.texture_coordinates.len(),
                 self.normals.len(),
-                true,
+                reverse_corners,
             )?;
 
             let aligned_vertices = normalized
@@ -353,15 +375,28 @@ impl VpxObjReader {
             })
         } else {
             // Strict fast path: each face is already a triangle with
-            // matching v/vt/vn. Reverse the per-triangle corner order to
-            // undo vpinball's `WriteFaceInfoLong` reversal.
+            // matching v/vt/vn. With `reverse_corners=true` we flip the
+            // per-triangle corner order to undo vpinball's
+            // `WriteFaceInfoLong` reversal; with `false` we preserve the
+            // source winding for callers importing OBJ files already in
+            // vpinball-internal convention.
             let indices = self
                 .raw_faces
                 .iter()
-                .map(|face| VpxFace {
-                    i0: face[2].v as i64 - 1,
-                    i1: face[1].v as i64 - 1,
-                    i2: face[0].v as i64 - 1,
+                .map(|face| {
+                    if reverse_corners {
+                        VpxFace {
+                            i0: face[2].v as i64 - 1,
+                            i1: face[1].v as i64 - 1,
+                            i2: face[0].v as i64 - 1,
+                        }
+                    } else {
+                        VpxFace {
+                            i0: face[0].v as i64 - 1,
+                            i1: face[1].v as i64 - 1,
+                            i2: face[2].v as i64 - 1,
+                        }
+                    }
                 })
                 .collect();
             Ok(ObjData {
@@ -438,8 +473,19 @@ impl ObjReader<f32> for VpxObjReader {
 
 #[instrument(skip(reader))]
 pub(crate) fn read_obj<R: BufRead>(mut reader: &mut R) -> std::io::Result<ObjData> {
-    let vpx_reader = VpxObjReader::new();
-    vpx_reader.read(&mut reader)
+    read_obj_with_options(&mut reader, true)
+}
+
+/// Like [`read_obj`] but lets the caller decide whether per-triangle
+/// face winding gets reversed. `reverse_corners=true` matches vpinball's
+/// `ObjLoader::Load` (which always reverses); `false` preserves the
+/// source's winding for callers that import OBJ files that are already
+/// in vpinball-internal convention.
+pub(crate) fn read_obj_with_options<R: BufRead>(
+    reader: &mut R,
+    reverse_corners: bool,
+) -> std::io::Result<ObjData> {
+    VpxObjReader::new().read(reader, reverse_corners)
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/vpx/obj.rs
+++ b/src/vpx/obj.rs
@@ -289,10 +289,11 @@ impl VpxObjReader {
     /// vpinball's `WriteFaceInfoLong`.
     ///
     /// Otherwise (Blender-style n-gons or mismatched corners), the
-    /// `obj_compat::normalize_for_vpinball` step runs over the collected
-    /// data: faces are corner-reversed, fan-triangulated and
-    /// `(pos, uv, normal)` corners are deduplicated. The v/vt/vn arrays are
-    /// rebuilt to be aligned (same length, one entry per combined corner).
+    /// [`triangulate_and_dedup`] step runs over the collected data with
+    /// `reverse_corners=true`: faces are corner-reversed, fan-triangulated
+    /// and `(pos, uv, normal)` corners are deduplicated. The v/vt/vn arrays
+    /// are rebuilt to be aligned (same length, one entry per combined
+    /// corner).
     fn read<R: io::Read>(mut self, reader: &mut R) -> io::Result<ObjData> {
         wavefront_obj_io::read_obj_file(reader, &mut self)?;
         if self.object_count != 1 {
@@ -306,11 +307,12 @@ impl VpxObjReader {
         }
 
         if self.needs_normalize {
-            let normalized = normalize_for_vpinball(
+            let normalized = triangulate_and_dedup(
                 &self.raw_faces,
                 self.vertices.len(),
                 self.texture_coordinates.len(),
                 self.normals.len(),
+                true,
             )?;
 
             let aligned_vertices = normalized
@@ -328,7 +330,7 @@ impl VpxObjReader {
                 .iter()
                 .map(|(_, _, n)| self.normals[*n].clone())
                 .collect();
-            // Triangles from `normalize_for_vpinball` are already in
+            // Triangles from `triangulate_and_dedup` are already in
             // vpinball's m_indices convention (matches the result of
             // `ObjLoader::Load`'s corner-reverse + fan-triangulate +
             // dedup). No further reversal needed here.
@@ -496,7 +498,7 @@ pub(crate) struct ObjData {
 
 /// One corner of a face as parsed from a `f` line. `vt` / `vn` are 0 when
 /// missing in the source - that turns into an `InvalidIndex` error during
-/// [`normalize_for_vpinball`].
+/// [`triangulate_and_dedup`].
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct FaceCorner {
     pub(crate) v: u32,
@@ -504,7 +506,7 @@ pub(crate) struct FaceCorner {
     pub(crate) vn: u32,
 }
 
-/// Result of [`normalize_for_vpinball`].
+/// Result of [`triangulate_and_dedup`].
 pub(crate) struct NormalizedFaces {
     /// One entry per unique combined `(pos_idx, uv_idx, normal_idx)` tuple,
     /// in the order it was first seen by the dedup walk. Indices are
@@ -534,18 +536,22 @@ fn resolve_index(idx: u32, len: usize, kind: &str, lineno_hint: &str) -> io::Res
     Ok(resolved)
 }
 
-/// Apply the format-level normalization that vpinball's `ObjLoader::Load`
-/// performs: reverse each face's corners, fan-triangulate, then deduplicate
-/// `(pos, uv, normal)` corners into a flat vertex array.
+/// Fan-triangulate every face and deduplicate `(pos, uv, normal)` corners
+/// into a flat vertex array.
 ///
-/// Used by both [`convert_to_vpinball_compat`] and the lenient path of
-/// [`read_obj_from_reader`] so that a Blender-exported OBJ produces the
-/// same mesh either way.
-pub(crate) fn normalize_for_vpinball(
+/// When `reverse_corners` is true, each face's corners are reversed before
+/// triangulation - matches vpinball's `ObjLoader::Load`, used by the
+/// lenient path of [`read_obj_from_reader`] so a Blender-exported OBJ
+/// produces the same mesh as vpinball would.
+///
+/// When false, faces triangulate in their original OBJ order, preserving
+/// the source winding direction. Used by the renderer-friendly mesh API.
+pub(crate) fn triangulate_and_dedup(
     raw_faces: &[Vec<FaceCorner>],
     positions_len: usize,
     tex_coords_len: usize,
     normals_len: usize,
+    reverse_corners: bool,
 ) -> io::Result<NormalizedFaces> {
     let mut triangles_with_corners: Vec<[(usize, usize, usize); 3]> =
         Vec::with_capacity(raw_faces.len());
@@ -564,7 +570,9 @@ pub(crate) fn normalize_for_vpinball(
             corners.push((p, t, n));
         }
 
-        corners.reverse();
+        if reverse_corners {
+            corners.reverse();
+        }
 
         // Fan triangulation: (0, i, i+1) for i in 1..n-1.
         for i in 1..corners.len() - 1 {

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -134,6 +134,219 @@ pub fn assemble(
     Ok(bytes)
 }
 
+// ---------------------------------------------------------------------------
+// Mesh I/O surface for vpx-editor and other wasm consumers.
+//
+// Symmetric with `extract` / `assemble`: `obj_to_mesh` applies the same
+// vpinball-format transforms that the read path applies (Z negate, V flip,
+// winding reverse) so the returned mesh data is in vpx-internal convention.
+// `mesh_to_obj` applies the inverse, producing an OBJ in vpinball-format
+// suitable for `assemble`.
+// ---------------------------------------------------------------------------
+
+/// Mesh data for a single primitive: positions, texture coordinates,
+/// normals and triangle indices, packed as flat typed arrays for direct
+/// upload into a WebGL / Three.js / GPU buffer.
+///
+/// All vertex data is aligned: `positions[3*i..3*i+3]`, `tex_coords[2*i..2*i+2]`
+/// and `normals[3*i..3*i+3]` describe corner `i`. Triangles are 0-based
+/// indices into that aligned array.
+///
+/// Coordinates are in vpx-internal convention (the same form `read_fs`
+/// produces and `write_fs` consumes), not raw OBJ values - see
+/// [`obj_to_mesh`] / [`mesh_to_obj`] for the transform details.
+///
+/// The published wasm package is built with `wasm-bindgen --weak-refs`,
+/// so the Rust-owned vectors backing this struct are reclaimed
+/// automatically via `FinalizationRegistry` when the JS wrapper is
+/// garbage-collected. Calling `.free()` manually is still allowed for
+/// deterministic cleanup of large meshes.
+#[wasm_bindgen]
+pub struct PrimitiveMesh {
+    name: String,
+    positions: Vec<f32>,
+    tex_coords: Vec<f32>,
+    normals: Vec<f32>,
+    indices: Vec<u32>,
+}
+
+#[wasm_bindgen]
+impl PrimitiveMesh {
+    #[wasm_bindgen(getter)]
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn positions(&self) -> js_sys::Float32Array {
+        js_sys::Float32Array::from(self.positions.as_slice())
+    }
+
+    #[wasm_bindgen(getter, js_name = texCoords)]
+    pub fn tex_coords(&self) -> js_sys::Float32Array {
+        js_sys::Float32Array::from(self.tex_coords.as_slice())
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn normals(&self) -> js_sys::Float32Array {
+        js_sys::Float32Array::from(self.normals.as_slice())
+    }
+
+    #[wasm_bindgen(getter)]
+    pub fn indices(&self) -> js_sys::Uint32Array {
+        js_sys::Uint32Array::from(self.indices.as_slice())
+    }
+}
+
+/// Parse a Wavefront OBJ into a [`PrimitiveMesh`]. Accepts any OBJ flavor
+/// Parse a Wavefront OBJ into a [`PrimitiveMesh`].
+///
+/// Accepts any OBJ flavor (vpinball-format from `extract`, Blender-format,
+/// anything in between): n-gons are fan-triangulated and `(position, uv,
+/// normal)` corners are deduplicated so the result is renderer-ready.
+///
+/// Applies the same transforms as `assemble`'s read path: vertex Z is
+/// negated, normal Z is negated, V coordinate is flipped (`vpx_tv = 1 -
+/// obj_v`), and the per-triangle corner order is reversed. The returned
+/// mesh data is in vpx-internal convention.
+#[wasm_bindgen]
+pub fn obj_to_mesh(data: &[u8]) -> Result<PrimitiveMesh, JsError> {
+    use crate::vpx::obj::read_obj_from_reader;
+    use std::io::BufReader;
+
+    let mut reader = BufReader::new(data);
+    let result = read_obj_from_reader(&mut reader)
+        .map_err(|e| JsError::new(&format!("OBJ parse failed: {}", e)))?;
+
+    let mut positions = Vec::with_capacity(result.final_vertices.len() * 3);
+    let mut tex_coords = Vec::with_capacity(result.final_vertices.len() * 2);
+    let mut normals = Vec::with_capacity(result.final_vertices.len() * 3);
+    for v in &result.final_vertices {
+        positions.push(v.x);
+        positions.push(v.y);
+        positions.push(v.z);
+        tex_coords.push(v.tu);
+        tex_coords.push(v.tv);
+        normals.push(v.nx);
+        normals.push(v.ny);
+        normals.push(v.nz);
+    }
+    let mut indices = Vec::with_capacity(result.indices.len() * 3);
+    for face in &result.indices {
+        indices.push(face.i0 as u32);
+        indices.push(face.i1 as u32);
+        indices.push(face.i2 as u32);
+    }
+
+    Ok(PrimitiveMesh {
+        name: result.name,
+        positions,
+        tex_coords,
+        normals,
+        indices,
+    })
+}
+
+/// Serialize a mesh as a Wavefront OBJ.
+///
+/// `name` becomes the `o` directive; pass an empty string to use
+/// `"object"`. Vertex / texcoord / normal arrays must have aligned
+/// lengths (`positions.len() / 3 == tex_coords.len() / 2 ==
+/// normals.len() / 3`); index values must be valid 0-based offsets into
+/// that vertex array.
+///
+/// Applies the same transforms as `extract`'s write path: vertex Z is
+/// negated, normal Z is negated, V coordinate is flipped (`obj_v = 1 -
+/// vpx_tv`), and per-triangle corner order is reversed. The result is a
+/// vpinball-format OBJ that `assemble` can read back into the same vpx
+/// data via the inverse transforms.
+#[wasm_bindgen]
+pub fn mesh_to_obj(
+    name: &str,
+    positions: &[f32],
+    tex_coords: &[f32],
+    normals: &[f32],
+    indices: &[u32],
+) -> Result<Vec<u8>, JsError> {
+    use wavefront_obj_io::{IoObjWriter, ObjWriter};
+
+    if !positions.len().is_multiple_of(3) {
+        return Err(JsError::new("positions length must be a multiple of 3"));
+    }
+    if !tex_coords.len().is_multiple_of(2) {
+        return Err(JsError::new("tex_coords length must be a multiple of 2"));
+    }
+    if !normals.len().is_multiple_of(3) {
+        return Err(JsError::new("normals length must be a multiple of 3"));
+    }
+    if !indices.len().is_multiple_of(3) {
+        return Err(JsError::new("indices length must be a multiple of 3"));
+    }
+    let vert_count = positions.len() / 3;
+    if tex_coords.len() / 2 != vert_count || normals.len() / 3 != vert_count {
+        return Err(JsError::new(
+            "positions / tex_coords / normals must describe the same vertex count",
+        ));
+    }
+
+    let mut buffer = Vec::with_capacity(positions.len() * 4);
+    {
+        let mut writer: IoObjWriter<&mut Vec<u8>, f32> = IoObjWriter::new(&mut buffer);
+        writer
+            .write_comment(format!(
+                "numVerts: {} numFaces: {}",
+                vert_count,
+                indices.len() / 3
+            ))
+            .map_err(|e| JsError::new(&format!("write failed: {e}")))?;
+        let object_name = if name.is_empty() { "object" } else { name };
+        writer
+            .write_object_name(object_name)
+            .map_err(|e| JsError::new(&format!("write failed: {e}")))?;
+
+        // Z negate on positions.
+        for chunk in positions.chunks_exact(3) {
+            writer
+                .write_vertex(chunk[0], chunk[1], -chunk[2], None)
+                .map_err(|e| JsError::new(&format!("write failed: {e}")))?;
+        }
+        // V flip on tex coords.
+        for chunk in tex_coords.chunks_exact(2) {
+            writer
+                .write_texture_coordinate(chunk[0], Some(1.0 - chunk[1]), None)
+                .map_err(|e| JsError::new(&format!("write failed: {e}")))?;
+        }
+        // Z negate on normals.
+        for chunk in normals.chunks_exact(3) {
+            writer
+                .write_normal(chunk[0], chunk[1], -chunk[2])
+                .map_err(|e| JsError::new(&format!("write failed: {e}")))?;
+        }
+        // Per-triangle corner reverse on faces; OBJ indices are 1-based.
+        for tri in indices.chunks_exact(3) {
+            for &idx in tri {
+                if idx as usize >= vert_count {
+                    return Err(JsError::new(&format!(
+                        "triangle index {idx} out of range (have {vert_count} vertices)"
+                    )));
+                }
+            }
+            let a = (tri[2] + 1) as usize;
+            let b = (tri[1] + 1) as usize;
+            let c = (tri[0] + 1) as usize;
+            writer
+                .write_face(&[
+                    (a, Some(a), Some(a)),
+                    (b, Some(b), Some(b)),
+                    (c, Some(c), Some(c)),
+                ])
+                .map_err(|e| JsError::new(&format!("write failed: {e}")))?;
+        }
+    }
+
+    Ok(buffer)
+}
+
 #[cfg(all(test, target_family = "wasm"))]
 mod tests {
     use super::*;
@@ -150,6 +363,70 @@ mod tests {
     fn test_assemble_with_empty_files() {
         let files = js_sys::Object::new();
         let result = assemble(files, None);
+        assert!(result.is_err());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_obj_to_mesh_blender_cube() {
+        // Blender's default cube exported as OBJ. 6 quads -> 12 triangles,
+        // 8 unique positions but 24 unique combined corners after dedup
+        // (each quad has its own normal, so no corner can be reused
+        // across adjacent faces).
+        let blender = include_bytes!("../testdata/blender_square.obj");
+        let mesh = obj_to_mesh(blender).expect("parse should succeed");
+        assert_eq!(mesh.name(), "Cube");
+
+        let positions = mesh.positions();
+        let tex_coords = mesh.tex_coords();
+        let normals = mesh.normals();
+        let indices = mesh.indices();
+
+        // 24 combined corners across 12 triangles.
+        assert_eq!(positions.length(), 24 * 3);
+        assert_eq!(tex_coords.length(), 24 * 2);
+        assert_eq!(normals.length(), 24 * 3);
+        assert_eq!(indices.length(), 12 * 3);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_obj_to_mesh_rejects_unparseable_input() {
+        let result = obj_to_mesh(b"this is not an obj");
+        // The lenient reader skips unknown lines; this fails on the
+        // post-parse "no vertices" check.
+        assert!(result.is_err());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_mesh_to_obj_round_trip() {
+        // obj_to_mesh -> mesh_to_obj -> obj_to_mesh: structure preserved.
+        let blender = include_bytes!("../testdata/blender_square.obj");
+        let mesh = obj_to_mesh(blender).expect("parse should succeed");
+
+        let positions: Vec<f32> = mesh.positions().to_vec();
+        let tex_coords: Vec<f32> = mesh.tex_coords().to_vec();
+        let normals: Vec<f32> = mesh.normals().to_vec();
+        let indices: Vec<u32> = mesh.indices().to_vec();
+
+        let obj_bytes = mesh_to_obj("Cube", &positions, &tex_coords, &normals, &indices)
+            .expect("write should succeed");
+
+        let round_tripped = obj_to_mesh(&obj_bytes).expect("reparse should succeed");
+        assert_eq!(round_tripped.positions().length(), positions.len() as u32);
+        assert_eq!(round_tripped.tex_coords().length(), tex_coords.len() as u32);
+        assert_eq!(round_tripped.normals().length(), normals.len() as u32);
+        assert_eq!(round_tripped.indices().length(), indices.len() as u32);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_mesh_to_obj_validates_aligned_arrays() {
+        // 3 positions but only 2 tex coords - should error.
+        let result = mesh_to_obj(
+            "bad",
+            &[0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            &[0.0, 0.0, 1.0, 0.0],
+            &[0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0],
+            &[0, 1, 2],
+        );
         assert!(result.is_err());
     }
 

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -419,6 +419,63 @@ pub fn mesh_to_obj(
     Ok(buffer)
 }
 
+/// Generate the procedural mesh used by vpinball primitives that
+/// don't load a `.obj` file (`use_3d_mesh = false`). Mirrors
+/// `Primitive::CalculateBuiltinOriginal` from vpinball: a regular
+/// polygon prism with `sides` faces, top and bottom caps, fitting
+/// in `[-r, r] x [-r, r] x [-0.5, 0.5]`.
+///
+/// Use this to render the placeholder shape for a primitive that
+/// has `use_3d_mesh = false`, or to seed the editor's "Add
+/// Primitive" workflow.
+///
+/// `sides` must be at least 3; otherwise the call errors out
+/// (vpinball clamps to 3 in its own editor).
+///
+/// `draw_textures_inside = true` doubles the index count so back
+/// faces are also rendered (matches vpinball's flag of the same
+/// name on `Primitive`). Vertex / texcoord / normal arrays are
+/// unaffected.
+#[wasm_bindgen]
+pub fn generate_builtin_primitive(
+    sides: u32,
+    draw_textures_inside: bool,
+) -> Result<PrimitiveMesh, JsError> {
+    use crate::vpx::mesh::builtin_primitive::build_builtin_primitive_mesh;
+
+    let (vertices, faces) = build_builtin_primitive_mesh(sides, draw_textures_inside)
+        .ok_or_else(|| JsError::new(&format!("sides must be >= 3 (got {sides})")))?;
+
+    let mut positions = Vec::with_capacity(vertices.len() * 3);
+    let mut tex_coords = Vec::with_capacity(vertices.len() * 2);
+    let mut normals = Vec::with_capacity(vertices.len() * 3);
+    for vw in &vertices {
+        let v = &vw.vertex;
+        positions.push(v.x);
+        positions.push(v.y);
+        positions.push(v.z);
+        tex_coords.push(v.tu);
+        tex_coords.push(v.tv);
+        normals.push(v.nx);
+        normals.push(v.ny);
+        normals.push(v.nz);
+    }
+    let mut indices = Vec::with_capacity(faces.len() * 3);
+    for face in &faces {
+        indices.push(face.i0 as u32);
+        indices.push(face.i1 as u32);
+        indices.push(face.i2 as u32);
+    }
+
+    Ok(PrimitiveMesh {
+        name: String::from("primitive"),
+        positions,
+        tex_coords,
+        normals,
+        indices,
+    })
+}
+
 #[cfg(all(test, target_family = "wasm"))]
 mod tests {
     use super::*;
@@ -524,6 +581,46 @@ mod tests {
             true,
         );
         assert!(result.is_err());
+    }
+
+    #[wasm_bindgen_test]
+    fn test_generate_builtin_primitive_shape() {
+        // A 4-sided builtin primitive: 4*4+2 = 18 vertices,
+        // 12*4 = 48 indices = 16 triangles. With
+        // draw_textures_inside, indices double to 32 triangles.
+        let mesh = generate_builtin_primitive(4, false).expect("should succeed");
+        assert_eq!(mesh.positions().length(), 18 * 3);
+        assert_eq!(mesh.tex_coords().length(), 18 * 2);
+        assert_eq!(mesh.normals().length(), 18 * 3);
+        assert_eq!(mesh.indices().length(), 16 * 3);
+
+        let mesh = generate_builtin_primitive(4, true).expect("should succeed");
+        assert_eq!(mesh.indices().length(), 32 * 3);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_generate_builtin_primitive_rejects_too_few_sides() {
+        for sides in 0..3 {
+            let result = generate_builtin_primitive(sides, false);
+            assert!(result.is_err(), "sides={sides} should error");
+        }
+    }
+
+    #[wasm_bindgen_test]
+    fn test_generate_builtin_primitive_round_trips_via_mesh_to_obj() {
+        // The builtin mesh feeds straight into mesh_to_obj; the
+        // resulting OBJ parses back to the same vertex/index counts.
+        let mesh = generate_builtin_primitive(8, false).expect("should succeed");
+        let positions: Vec<f32> = mesh.positions().to_vec();
+        let tex_coords: Vec<f32> = mesh.tex_coords().to_vec();
+        let normals: Vec<f32> = mesh.normals().to_vec();
+        let indices: Vec<u32> = mesh.indices().to_vec();
+
+        let obj_bytes = mesh_to_obj("octa", &positions, &tex_coords, &normals, &indices, false)
+            .expect("write should succeed");
+        let parsed = obj_to_mesh(&obj_bytes, false).expect("reparse should succeed");
+        assert_eq!(parsed.positions().to_vec(), positions);
+        assert_eq!(parsed.indices().to_vec(), indices);
     }
 
     #[wasm_bindgen_test]

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -137,11 +137,17 @@ pub fn assemble(
 // ---------------------------------------------------------------------------
 // Mesh I/O surface for vpx-editor and other wasm consumers.
 //
-// Symmetric with `extract` / `assemble`: `obj_to_mesh` applies the same
-// vpinball-format transforms that the read path applies (Z negate, V flip,
-// winding reverse) so the returned mesh data is in vpx-internal convention.
-// `mesh_to_obj` applies the inverse, producing an OBJ in vpinball-format
-// suitable for `assemble`.
+// `obj_to_mesh` parses an OBJ into renderer-ready typed arrays;
+// `mesh_to_obj` is its symmetric inverse. Both take a
+// `convert_to_left_handed` flag matching vpinball's `ObjLoader::Load`
+// flag of the same name (the "Convert coordinate system" checkbox in
+// vpinball's mesh-import dialog):
+// - `true`: apply Z negate / V flip / winding reverse to convert
+//   between the OBJ's right-handed Y-up convention (Blender / standard)
+//   and vpx-internal left-handed Z-up. Symmetric with `extract` /
+//   `assemble`.
+// - `false`: skip the conversion. Input is assumed to already be in
+//   vpx-internal convention; values pass through unchanged.
 // ---------------------------------------------------------------------------
 
 /// Mesh data for a single primitive: positions, texture coordinates,
@@ -196,26 +202,70 @@ impl PrimitiveMesh {
     pub fn indices(&self) -> js_sys::Uint32Array {
         js_sys::Uint32Array::from(self.indices.as_slice())
     }
+
+    /// Bounding-box midpoint of the mesh's positions, in the same
+    /// coordinate space as `positions` (vpx-internal). Returns
+    /// `[mid_x, mid_y, mid_z]`. Used by editor flows that center the
+    /// mesh on origin or move the primitive to the mesh's absolute
+    /// position - both need to know the midpoint to shift vertices
+    /// (and, for the absolute-position case, to set the primitive's
+    /// `vPosition` field). Mirrors vpinball's `Mesh::middlePoint`,
+    /// which is used by `IDC_CENTER_MESH` / `IDC_ABS_POSITION_RADIO`
+    /// in the mesh-import dialog (`primitive.cpp:1729-1745`).
+    ///
+    /// Returns `[0, 0, 0]` for an empty mesh.
+    #[wasm_bindgen(getter)]
+    pub fn midpoint(&self) -> js_sys::Float32Array {
+        if self.positions.is_empty() {
+            return js_sys::Float32Array::from([0.0_f32, 0.0, 0.0].as_slice());
+        }
+        let mut min = [f32::INFINITY; 3];
+        let mut max = [f32::NEG_INFINITY; 3];
+        for chunk in self.positions.chunks_exact(3) {
+            for axis in 0..3 {
+                if chunk[axis] < min[axis] {
+                    min[axis] = chunk[axis];
+                }
+                if chunk[axis] > max[axis] {
+                    max[axis] = chunk[axis];
+                }
+            }
+        }
+        let mid = [
+            (min[0] + max[0]) * 0.5,
+            (min[1] + max[1]) * 0.5,
+            (min[2] + max[2]) * 0.5,
+        ];
+        js_sys::Float32Array::from(mid.as_slice())
+    }
 }
 
-/// Parse a Wavefront OBJ into a [`PrimitiveMesh`]. Accepts any OBJ flavor
 /// Parse a Wavefront OBJ into a [`PrimitiveMesh`].
 ///
 /// Accepts any OBJ flavor (vpinball-format from `extract`, Blender-format,
 /// anything in between): n-gons are fan-triangulated and `(position, uv,
 /// normal)` corners are deduplicated so the result is renderer-ready.
 ///
-/// Applies the same transforms as `assemble`'s read path: vertex Z is
-/// negated, normal Z is negated, V coordinate is flipped (`vpx_tv = 1 -
-/// obj_v`), and the per-triangle corner order is reversed. The returned
-/// mesh data is in vpx-internal convention.
+/// `convert_to_left_handed` mirrors vpinball's `ObjLoader::Load` flag of
+/// the same name (the "Convert coordinate system" checkbox in the
+/// vpinball mesh-import dialog):
+///
+/// - `true` (matches `assemble`'s read path and vpinball's dialog
+///   default): the input is treated as right-handed (Blender / standard
+///   convention). Vertex Z is negated, normal Z is negated, V is flipped
+///   (`vpx_tv = 1 - obj_v`), and the per-triangle corner order is
+///   reversed. The returned mesh data ends up in vpx-internal,
+///   left-handed convention.
+/// - `false`: the input is assumed to already be in vpx-internal
+///   convention (e.g. produced by a previous `mesh_to_obj` with the same
+///   flag). The transforms are skipped and values pass through verbatim.
 #[wasm_bindgen]
-pub fn obj_to_mesh(data: &[u8]) -> Result<PrimitiveMesh, JsError> {
-    use crate::vpx::obj::read_obj_from_reader;
+pub fn obj_to_mesh(data: &[u8], convert_to_left_handed: bool) -> Result<PrimitiveMesh, JsError> {
+    use crate::vpx::obj::read_obj_from_reader_with_options;
     use std::io::BufReader;
 
     let mut reader = BufReader::new(data);
-    let result = read_obj_from_reader(&mut reader)
+    let result = read_obj_from_reader_with_options(&mut reader, convert_to_left_handed)
         .map_err(|e| JsError::new(&format!("OBJ parse failed: {}", e)))?;
 
     let mut positions = Vec::with_capacity(result.final_vertices.len() * 3);
@@ -255,11 +305,16 @@ pub fn obj_to_mesh(data: &[u8]) -> Result<PrimitiveMesh, JsError> {
 /// normals.len() / 3`); index values must be valid 0-based offsets into
 /// that vertex array.
 ///
-/// Applies the same transforms as `extract`'s write path: vertex Z is
-/// negated, normal Z is negated, V coordinate is flipped (`obj_v = 1 -
-/// vpx_tv`), and per-triangle corner order is reversed. The result is a
-/// vpinball-format OBJ that `assemble` can read back into the same vpx
-/// data via the inverse transforms.
+/// `convert_to_left_handed` is the symmetric inverse of the same flag
+/// on [`obj_to_mesh`]:
+///
+/// - `true` (matches `extract`'s write path): the input is treated as
+///   vpx-internal data and converted out: vertex Z is negated, normal Z
+///   is negated, V is flipped (`obj_v = 1 - vpx_tv`), and per-triangle
+///   corner order is reversed. The result is a vpinball-format OBJ
+///   that `assemble` (or `obj_to_mesh(.., true)`) reads back identically.
+/// - `false`: the input vpx-internal data is written out verbatim, no
+///   transforms applied. Round-trips with `obj_to_mesh(.., false)`.
 #[wasm_bindgen]
 pub fn mesh_to_obj(
     name: &str,
@@ -267,6 +322,7 @@ pub fn mesh_to_obj(
     tex_coords: &[f32],
     normals: &[f32],
     indices: &[u32],
+    convert_to_left_handed: bool,
 ) -> Result<Vec<u8>, JsError> {
     use wavefront_obj_io::{IoObjWriter, ObjWriter};
 
@@ -304,25 +360,31 @@ pub fn mesh_to_obj(
             .write_object_name(object_name)
             .map_err(|e| JsError::new(&format!("write failed: {e}")))?;
 
-        // Z negate on positions.
+        let z_sign = if convert_to_left_handed { -1.0 } else { 1.0 };
         for chunk in positions.chunks_exact(3) {
             writer
-                .write_vertex(chunk[0], chunk[1], -chunk[2], None)
+                .write_vertex(chunk[0], chunk[1], z_sign * chunk[2], None)
                 .map_err(|e| JsError::new(&format!("write failed: {e}")))?;
         }
-        // V flip on tex coords.
         for chunk in tex_coords.chunks_exact(2) {
+            let v_out = if convert_to_left_handed {
+                1.0 - chunk[1]
+            } else {
+                chunk[1]
+            };
             writer
-                .write_texture_coordinate(chunk[0], Some(1.0 - chunk[1]), None)
+                .write_texture_coordinate(chunk[0], Some(v_out), None)
                 .map_err(|e| JsError::new(&format!("write failed: {e}")))?;
         }
-        // Z negate on normals.
         for chunk in normals.chunks_exact(3) {
             writer
-                .write_normal(chunk[0], chunk[1], -chunk[2])
+                .write_normal(chunk[0], chunk[1], z_sign * chunk[2])
                 .map_err(|e| JsError::new(&format!("write failed: {e}")))?;
         }
-        // Per-triangle corner reverse on faces; OBJ indices are 1-based.
+        // OBJ indices are 1-based. With `convert_to_left_handed=true`
+        // we reverse the per-triangle corner order (matching vpinball's
+        // `WriteFaceInfoLong`); with `false` we keep source winding so
+        // round-trips with `obj_to_mesh(.., false)` preserve indices.
         for tri in indices.chunks_exact(3) {
             for &idx in tri {
                 if idx as usize >= vert_count {
@@ -331,9 +393,19 @@ pub fn mesh_to_obj(
                     )));
                 }
             }
-            let a = (tri[2] + 1) as usize;
-            let b = (tri[1] + 1) as usize;
-            let c = (tri[0] + 1) as usize;
+            let (a, b, c) = if convert_to_left_handed {
+                (
+                    (tri[2] + 1) as usize,
+                    (tri[1] + 1) as usize,
+                    (tri[0] + 1) as usize,
+                )
+            } else {
+                (
+                    (tri[0] + 1) as usize,
+                    (tri[1] + 1) as usize,
+                    (tri[2] + 1) as usize,
+                )
+            };
             writer
                 .write_face(&[
                     (a, Some(a), Some(a)),
@@ -373,7 +445,7 @@ mod tests {
         // (each quad has its own normal, so no corner can be reused
         // across adjacent faces).
         let blender = include_bytes!("../testdata/blender_square.obj");
-        let mesh = obj_to_mesh(blender).expect("parse should succeed");
+        let mesh = obj_to_mesh(blender, true).expect("parse should succeed");
         assert_eq!(mesh.name(), "Cube");
 
         let positions = mesh.positions();
@@ -390,7 +462,7 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_obj_to_mesh_rejects_unparseable_input() {
-        let result = obj_to_mesh(b"this is not an obj");
+        let result = obj_to_mesh(b"this is not an obj", true);
         // The lenient reader skips unknown lines; this fails on the
         // post-parse "no vertices" check.
         assert!(result.is_err());
@@ -400,21 +472,44 @@ mod tests {
     fn test_mesh_to_obj_round_trip() {
         // obj_to_mesh -> mesh_to_obj -> obj_to_mesh: structure preserved.
         let blender = include_bytes!("../testdata/blender_square.obj");
-        let mesh = obj_to_mesh(blender).expect("parse should succeed");
+        let mesh = obj_to_mesh(blender, true).expect("parse should succeed");
 
         let positions: Vec<f32> = mesh.positions().to_vec();
         let tex_coords: Vec<f32> = mesh.tex_coords().to_vec();
         let normals: Vec<f32> = mesh.normals().to_vec();
         let indices: Vec<u32> = mesh.indices().to_vec();
 
-        let obj_bytes = mesh_to_obj("Cube", &positions, &tex_coords, &normals, &indices)
+        let obj_bytes = mesh_to_obj("Cube", &positions, &tex_coords, &normals, &indices, true)
             .expect("write should succeed");
 
-        let round_tripped = obj_to_mesh(&obj_bytes).expect("reparse should succeed");
+        let round_tripped = obj_to_mesh(&obj_bytes, true).expect("reparse should succeed");
         assert_eq!(round_tripped.positions().length(), positions.len() as u32);
         assert_eq!(round_tripped.tex_coords().length(), tex_coords.len() as u32);
         assert_eq!(round_tripped.normals().length(), normals.len() as u32);
         assert_eq!(round_tripped.indices().length(), indices.len() as u32);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_mesh_to_obj_round_trip_no_convert() {
+        // With `convert_to_left_handed=false`, vpx-internal data passes
+        // through verbatim - both vertex Z and triangle indices keep
+        // their original values across a round trip.
+        let positions: Vec<f32> = vec![0.0, 0.0, 0.5, 1.0, 0.0, 0.5, 0.0, 1.0, 0.5];
+        let tex_coords: Vec<f32> = vec![0.0, 0.25, 1.0, 0.25, 0.0, 0.75];
+        let normals: Vec<f32> = vec![0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0];
+        let indices: Vec<u32> = vec![0, 1, 2];
+
+        let obj_bytes = mesh_to_obj("tri", &positions, &tex_coords, &normals, &indices, false)
+            .expect("write should succeed");
+
+        let parsed = obj_to_mesh(&obj_bytes, false).expect("reparse should succeed");
+        let parsed_positions: Vec<f32> = parsed.positions().to_vec();
+        let parsed_tex_coords: Vec<f32> = parsed.tex_coords().to_vec();
+        let parsed_indices: Vec<u32> = parsed.indices().to_vec();
+
+        assert_eq!(parsed_positions, positions);
+        assert_eq!(parsed_tex_coords, tex_coords);
+        assert_eq!(parsed_indices, indices);
     }
 
     #[wasm_bindgen_test]
@@ -426,6 +521,7 @@ mod tests {
             &[0.0, 0.0, 1.0, 0.0],
             &[0.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0],
             &[0, 1, 2],
+            true,
         );
         assert!(result.is_err());
     }

--- a/wasm-readme.md
+++ b/wasm-readme.md
@@ -11,7 +11,7 @@ npm install @francisdb/vpin-wasm
 ## Usage
 
 ```typescript
-import init, { extract, assemble } from '@francisdb/vpin-wasm';
+import init, { extract, assemble, obj_to_mesh, mesh_to_obj } from '@francisdb/vpin-wasm';
 
 await init();
 ```
@@ -61,6 +61,58 @@ const vpxBytes = assemble(files, (message) => {
 - `callback?: (message: string) => void` - Optional progress callback
 
 **Returns:** `Uint8Array` - VPX file bytes
+
+### obj_to_mesh(data) / mesh_to_obj(name, positions, texCoords, normals, indices)
+
+Renderer-friendly mesh I/O. `obj_to_mesh` parses any flavor of OBJ
+(n-gons fan-triangulated, mismatched `v/vt/vn` corners deduplicated)
+into typed arrays you can hand straight to WebGL or Three.js. No
+JS-side OBJ parser needed.
+
+```typescript
+const objBytes = files['/vpx/gameitems/Primitive.MyMesh.obj'];
+const mesh = obj_to_mesh(objBytes);
+
+// mesh.name: string
+// mesh.positions: Float32Array  (length = 3 * vertCount, x,y,z,...)
+// mesh.texCoords: Float32Array  (length = 2 * vertCount, u,v,...)
+// mesh.normals:   Float32Array  (length = 3 * vertCount, nx,ny,nz,...)
+// mesh.indices:   Uint32Array   (length = 3 * triCount)
+
+// Three.js example:
+const geom = new THREE.BufferGeometry();
+geom.setAttribute('position', new THREE.BufferAttribute(mesh.positions, 3));
+geom.setAttribute('uv',       new THREE.BufferAttribute(mesh.texCoords, 2));
+geom.setAttribute('normal',   new THREE.BufferAttribute(mesh.normals, 3));
+geom.setIndex(new THREE.BufferAttribute(mesh.indices, 1));
+```
+
+`mesh_to_obj` does the inverse - serializes typed arrays back to OBJ
+bytes you can save into the file map and feed to `assemble`.
+
+```typescript
+const obj = mesh_to_obj(mesh.name, mesh.positions, mesh.texCoords, mesh.normals, mesh.indices);
+files['/vpx/gameitems/Primitive.MyMesh.obj'] = obj;
+```
+
+The published wasm bundle is built with `wasm-bindgen --weak-refs`, so
+the Rust-owned memory backing each `mesh` is reclaimed automatically
+via `FinalizationRegistry` when the JS wrapper is garbage-collected.
+You may call `mesh.free()` explicitly for deterministic cleanup of
+large meshes, but it is not required.
+
+**Coordinate convention:** the mesh data is in vpx-internal form -
+`obj_to_mesh` applies the same transforms as `assemble`'s read path
+(vertex Z negated, normal Z negated, V coordinate flipped, per-triangle
+corner order reversed), and `mesh_to_obj` applies the inverse, matching
+`extract`'s write path. Round-trip
+`obj_to_mesh -> edit -> mesh_to_obj -> assemble` preserves vpx data by
+construction. If your renderer uses a different convention than
+vpinball's left-handed +Z up, apply a transform matrix on the JS side.
+
+**Animation frames:** primitives with vertex animation extract as
+sibling files `Primitive.MyMesh_00000.obj`, `Primitive.MyMesh_00001.obj`,
+... Call `obj_to_mesh` per file and drive the timeline yourself.
 
 ### Exporting from Blender
 


### PR DESCRIPTION
Renderer-friendly mesh I/O for vpx-editor and other wasm consumers, mirroring vpinball's `ObjLoader::Load` / mesh-import dialog:

```typescript
const mesh = obj_to_mesh(objBytes, convertToLeftHanded);
// mesh.positions / texCoords / normals  -> Float32Array
// mesh.indices                            -> Uint32Array
// mesh.midpoint                           -> Float32Array (bbox midpoint, for Center mesh / absolute position)
// feed straight into Three.js BufferGeometry, WebGL, etc.

const objBytes = mesh_to_obj(name, positions, texCoords, normals, indices, convertToLeftHanded);
```

`convertToLeftHanded` matches vpinball's flag of the same name and the editor's "Convert coordinate system" checkbox:

- **`true`**: input is right-handed Y-up (Blender / standard); convert to vpx-internal left-handed Z-up (Z negate, V flip, winding reverse). Symmetric with `extract` / `assemble`.
- **`false`**: pass-through. Input is already in vpx-internal convention; values round-trip verbatim with `mesh_to_obj(.., false)`.

`obj_to_mesh` is lenient (n-gons fan-triangulated, mismatched `v/vt/vn` corners deduplicated). Animation frames are sibling files (`_00000.obj`, `_00001.obj`, ...) so the per-OBJ API handles them without special support.

Built with `wasm-bindgen --weak-refs` so Rust-owned vectors GC automatically; `.free()` is still available for deterministic cleanup.

Tests: 5 wasm-bindgen tests covering parse, error path, both round-trip variants, and aligned-array validation. Native build, wasm build, clippy `--all-features` and fmt all clean.