### PR TITLE
feat: full table obj export

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ sanitize-filename = "0.6"
 log = "0.4"
 tracing = "0.1"
 itoa = "1.0.15"
-wavefront-obj-io = "0.1.1"
+wavefront-obj-io = "0.2.0"
 rayon = { version = "1.11.0", optional = true }
 wasm-bindgen = { version = "0.2.108", optional = true }
 js-sys = { version = "0.3.85", optional = true }

--- a/examples/export_table_glb.rs
+++ b/examples/export_table_glb.rs
@@ -5,7 +5,7 @@
 use std::path::PathBuf;
 use vpin::filesystem::RealFileSystem;
 use vpin::vpx;
-use vpin::vpx::export::gltf_export::{GltfExportOptions, GltfFormat, export_with_options};
+use vpin::vpx::export::gltf_export::{GltfExportOptions, GltfFormat, export_gltf};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize logger - set RUST_LOG=warn (or info, debug) to see warnings
@@ -93,7 +93,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         format,
         export_invisible_items: export_invisible,
     };
-    export_with_options(&vpx, &output_path, &RealFileSystem, &options)?;
+    export_gltf(&vpx, &output_path, &RealFileSystem, &options)?;
 
     // Get file size(s)
     let metadata = std::fs::metadata(&output_path)?;

--- a/examples/export_table_obj.rs
+++ b/examples/export_table_obj.rs
@@ -1,0 +1,63 @@
+// Example showing how to export an entire VPX table as a Wavefront OBJ + MTL +
+// images folder.
+//
+// Output layout, given `path/to/table.vpx`:
+//
+//   path/to/table_export/
+//   ├── table.obj
+//   ├── table.mtl
+//   └── images/
+//       └── <texture-name>.<ext>
+//
+// The resulting .obj can be opened in any 3D viewer (Blender, MeshLab, ...).
+
+use std::path::PathBuf;
+use vpin::filesystem::RealFileSystem;
+use vpin::vpx;
+use vpin::vpx::export::obj_export::export_obj;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
+
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        eprintln!("Usage: cargo run --example export_table_obj <path_to_vpx>");
+        std::process::exit(1);
+    }
+
+    let vpx_path = PathBuf::from(&args[1]);
+    if !vpx_path.exists() {
+        eprintln!("Error: file not found: {}", vpx_path.display());
+        std::process::exit(1);
+    }
+
+    let stem = vpx_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .ok_or("vpx path has no usable file stem")?
+        .to_string();
+
+    let parent = vpx_path
+        .parent()
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("."));
+    let out_dir = parent.join(format!("{stem}_export"));
+    let obj_path = out_dir.join(format!("{stem}.obj"));
+
+    println!("Reading VPX file: {}", vpx_path.display());
+    let vpx = vpx::read(&vpx_path)?;
+
+    println!("Exporting to {}", obj_path.display());
+    export_obj(&vpx, &obj_path, &RealFileSystem)?;
+
+    let obj_size = std::fs::metadata(&obj_path)?.len();
+    let mtl_path = obj_path.with_extension("mtl");
+    let mtl_size = std::fs::metadata(&mtl_path)?.len();
+
+    println!("Done.");
+    println!("  obj:    {} ({} bytes)", obj_path.display(), obj_size);
+    println!("  mtl:    {} ({} bytes)", mtl_path.display(), mtl_size);
+    println!("  images: {}", out_dir.join("images").display());
+
+    Ok(())
+}

--- a/examples/export_table_obj.rs
+++ b/examples/export_table_obj.rs
@@ -14,7 +14,7 @@
 use std::path::PathBuf;
 use vpin::filesystem::RealFileSystem;
 use vpin::vpx;
-use vpin::vpx::export::obj_export::export_obj;
+use vpin::vpx::export::obj_export::{ObjExportOptions, export_obj};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("warn")).init();
@@ -48,7 +48,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let vpx = vpx::read(&vpx_path)?;
 
     println!("Exporting to {}", obj_path.display());
-    export_obj(&vpx, &obj_path, &RealFileSystem)?;
+    export_obj(
+        &vpx,
+        &obj_path,
+        &RealFileSystem,
+        &ObjExportOptions::default(),
+    )?;
 
     let obj_size = std::fs::metadata(&obj_path)?.len();
     let mtl_path = obj_path.with_extension("mtl");

--- a/src/vpx/expanded/mod.rs
+++ b/src/vpx/expanded/mod.rs
@@ -20,7 +20,7 @@ mod materials;
 mod metadata;
 mod primitives;
 mod sounds;
-mod util;
+pub(crate) mod util;
 
 use crate::filesystem::{FileSystem, MemoryFileSystem, RealFileSystem};
 use crate::vpx::gameitem::primitive::VertexWrapper;

--- a/src/vpx/expanded/util.rs
+++ b/src/vpx/expanded/util.rs
@@ -10,7 +10,7 @@ use std::path::Path;
 //   Eg a vpx extracted on linux could fail to be opened on Windows if the sound name
 //   contains such characters.
 //   This should probably be improved in the future
-pub(super) fn sanitize_filename<S: AsRef<str>>(name: S) -> String {
+pub(crate) fn sanitize_filename<S: AsRef<str>>(name: S) -> String {
     sanitize_filename::sanitize(name)
 }
 

--- a/src/vpx/export/gltf_export.rs
+++ b/src/vpx/export/gltf_export.rs
@@ -3024,79 +3024,26 @@ impl GltfExportOptions {
 /// Ignored for now
 /// - Lights (from game items and default table lights)
 ///
-/// # Arguments
-/// * `vpx` - The VPX table to export
-/// * `path` - The output path for the GLB file
-/// * `fs` - The filesystem to write to
+/// The output format (GLB vs glTF + sidecar `.bin`) and other knobs
+/// come from `options`. See [`GltfExportOptions`] (and its
+/// [`GltfExportOptions::glb`] / [`GltfExportOptions::gltf`] shortcuts).
 ///
 /// # Example
 /// ```no_run
 /// use vpin::vpx;
-/// use vpin::vpx::export::gltf_export::export_glb;
+/// use vpin::vpx::export::gltf_export::{export_gltf, GltfExportOptions};
 /// use vpin::filesystem::RealFileSystem;
 /// use std::path::Path;
 ///
 /// let vpx = vpx::read(Path::new("table.vpx")).unwrap();
-/// export_glb(&vpx, Path::new("table.glb"), &RealFileSystem).unwrap();
+/// export_gltf(
+///     &vpx,
+///     Path::new("table.glb"),
+///     &RealFileSystem,
+///     &GltfExportOptions::glb(),
+/// ).unwrap();
 /// ```
-pub fn export_glb(vpx: &VPX, path: &Path, fs: &dyn FileSystem) -> io::Result<()> {
-    export_with_options(vpx, path, fs, &GltfExportOptions::glb())
-}
-
-/// Export the entire VPX table as glTF files (JSON + separate binary)
-///
-/// This creates:
-/// - `{name}.gltf` - JSON descriptor file
-/// - `{name}.bin` - Binary buffer data (mesh geometry)
-///
-/// Note: Images are embedded in the binary buffer, not as separate files.
-///
-/// # Arguments
-/// * `vpx` - The VPX table to export
-/// * `path` - The output path for the .gltf file
-/// * `fs` - The filesystem to write to
-///
-/// # Example
-/// ```no_run
-/// use vpin::vpx;
-/// use vpin::vpx::export::gltf_export::export_gltf;
-/// use vpin::filesystem::RealFileSystem;
-/// use std::path::Path;
-///
-/// let vpx = vpx::read(Path::new("table.vpx")).unwrap();
-/// export_gltf(&vpx, Path::new("table.gltf"), &RealFileSystem).unwrap();
-/// ```
-pub fn export_gltf(vpx: &VPX, path: &Path, fs: &dyn FileSystem) -> io::Result<()> {
-    export_with_options(vpx, path, fs, &GltfExportOptions::gltf())
-}
-
-/// Export the entire VPX table in the specified format (GLB or glTF)
-///
-/// # Arguments
-/// * `vpx` - The VPX table to export
-/// * `path` - The output path (.glb or .gltf)
-/// * `fs` - The filesystem to write to
-/// * `format` - The output format (GLB or glTF)
-pub fn export(vpx: &VPX, path: &Path, fs: &dyn FileSystem, format: GltfFormat) -> io::Result<()> {
-    export_with_options(
-        vpx,
-        path,
-        fs,
-        &GltfExportOptions {
-            format,
-            ..Default::default()
-        },
-    )
-}
-
-/// Export the entire VPX table with full control over export options
-///
-/// # Arguments
-/// * `vpx` - The VPX table to export
-/// * `path` - The output path (.glb or .gltf)
-/// * `fs` - The filesystem to write to
-/// * `options` - Export options controlling format and behavior
-pub fn export_with_options(
+pub fn export_gltf(
     vpx: &VPX,
     path: &Path,
     fs: &dyn FileSystem,
@@ -3248,7 +3195,7 @@ mod tests {
         let vpx = VPX::default();
         let fs = crate::filesystem::MemoryFileSystem::default();
         // Should succeed because we generate an implicit playfield
-        let result = export_glb(&vpx, Path::new("test.glb"), &fs);
+        let result = export_gltf(&vpx, Path::new("test.glb"), &fs, &GltfExportOptions::glb());
         assert!(result.is_ok());
     }
 
@@ -3257,7 +3204,12 @@ mod tests {
         let vpx = VPX::default();
         let fs = crate::filesystem::MemoryFileSystem::default();
         // Should succeed and create both .gltf and .bin files
-        let result = export_gltf(&vpx, Path::new("test.gltf"), &fs);
+        let result = export_gltf(
+            &vpx,
+            Path::new("test.gltf"),
+            &fs,
+            &GltfExportOptions::gltf(),
+        );
         assert!(result.is_ok());
 
         // Verify both files were created

--- a/src/vpx/export/mod.rs
+++ b/src/vpx/export/mod.rs
@@ -1,2 +1,3 @@
 mod camera;
 pub mod gltf_export;
+pub mod obj_export;

--- a/src/vpx/export/obj_export.rs
+++ b/src/vpx/export/obj_export.rs
@@ -56,6 +56,25 @@ use std::io;
 use std::path::{Path, PathBuf};
 use wavefront_obj_io::{IoMtlWriter, IoObjWriter, MapKind, MtlWriter, ObjWriter, SmoothingGroup};
 
+/// Options controlling OBJ export behaviour. Defaults match VPinball's
+/// own `File -> Export -> OBJ Mesh` byte for byte.
+#[derive(Debug, Clone, Default)]
+pub struct ObjExportOptions {
+    /// Deduplicate `newmtl` blocks in the MTL file by `(material,
+    /// texture)` pair.
+    ///
+    /// - **`false` (default)**: emit one `newmtl` block per `usemtl`,
+    ///   matching VPinball's output exactly. The MTL contains one entry
+    ///   per item-block, which can mean many duplicates for tables that
+    ///   share materials across items.
+    /// - **`true`**: only the first occurrence of each `(material,
+    ///   texture)` pair gets a `newmtl` block. The `usemtl` references
+    ///   in the OBJ still resolve correctly (they all point at the same
+    ///   sanitized name). Produces a smaller MTL but diverges from
+    ///   VPinball's reference output.
+    pub dedup_mtl_blocks: bool,
+}
+
 /// Export the entire VPX table as a Wavefront OBJ + companion MTL + images
 /// folder.
 ///
@@ -63,17 +82,30 @@ use wavefront_obj_io::{IoMtlWriter, IoObjWriter, MapKind, MtlWriter, ObjWriter, 
 /// material library), and `<obj_path-parent>/images/<image>.<ext>` for every
 /// texture referenced by the exported items.
 ///
+/// See [`ObjExportOptions`] for what's tunable. `&ObjExportOptions::default()`
+/// produces VPinball-faithful output.
+///
 /// # Example
 /// ```no_run
 /// use std::path::Path;
 /// use vpin::filesystem::RealFileSystem;
 /// use vpin::vpx;
-/// use vpin::vpx::export::obj_export::export_obj;
+/// use vpin::vpx::export::obj_export::{export_obj, ObjExportOptions};
 ///
 /// let vpx = vpx::read(Path::new("table.vpx")).unwrap();
-/// export_obj(&vpx, Path::new("table_export/table.obj"), &RealFileSystem).unwrap();
+/// export_obj(
+///     &vpx,
+///     Path::new("table_export/table.obj"),
+///     &RealFileSystem,
+///     &ObjExportOptions::default(),
+/// ).unwrap();
 /// ```
-pub fn export_obj(vpx: &VPX, obj_path: &Path, fs: &dyn FileSystem) -> io::Result<()> {
+pub fn export_obj(
+    vpx: &VPX,
+    obj_path: &Path,
+    fs: &dyn FileSystem,
+    options: &ObjExportOptions,
+) -> io::Result<()> {
     let dir = obj_path
         .parent()
         .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "obj_path has no parent"))?;
@@ -98,7 +130,7 @@ pub fn export_obj(vpx: &VPX, obj_path: &Path, fs: &dyn FileSystem) -> io::Result
         obj_writer.write_material_lib(&[mtl_filename.as_str()])?;
         mtl_writer.write_comment("VPin table mat file")?;
 
-        let mut state = WriterState::new(vpx, &images_dir);
+        let mut state = WriterState::new(vpx, &images_dir, options);
 
         // 1. Implicit playfield quad (always emitted, matches VPinball
         //    PinTable::ExportMesh).
@@ -151,10 +183,16 @@ struct WriterState<'a> {
     image_dedup_counter: u32,
     /// VPX image names already written to disk. Skip subsequent encounters.
     images_written: HashSet<String>,
+    /// Whether to dedup `newmtl` blocks in the MTL file. See
+    /// [`ObjExportOptions::dedup_mtl_blocks`].
+    dedup_mtl_blocks: bool,
+    /// `(material_name, texture_name)` pairs already emitted as a
+    /// `newmtl` block. Only consulted when `dedup_mtl_blocks` is true.
+    seen_mtl_pairs: HashSet<(String, String)>,
 }
 
 impl<'a> WriterState<'a> {
-    fn new(vpx: &'a VPX, images_dir: &Path) -> Self {
+    fn new(vpx: &'a VPX, images_dir: &Path, options: &ObjExportOptions) -> Self {
         Self {
             vpx,
             images_dir: images_dir.to_path_buf(),
@@ -170,6 +208,8 @@ impl<'a> WriterState<'a> {
             used_lower_filenames: HashSet::new(),
             image_dedup_counter: 0,
             images_written: HashSet::new(),
+            dedup_mtl_blocks: options.dedup_mtl_blocks,
+            seen_mtl_pairs: HashSet::new(),
         }
     }
 
@@ -1043,10 +1083,17 @@ fn write_block<O: ObjWriter<f32>, M: MtlWriter<f32>>(
     Ok(())
 }
 
-/// Emit one `newmtl` block (no dedup, matches VPinball) and write the
-/// referenced image to disk on first use. Returns the material name as
-/// written (with spaces erased - VPinball does the same in `WriteMaterial`
-/// for both the MTL block and the `usemtl`).
+/// Emit a `newmtl` block and write the referenced image to disk on
+/// first use. Returns the material name as written (with spaces erased -
+/// VPinball does the same in `WriteMaterial` for both the MTL block and
+/// the `usemtl`).
+///
+/// By default vpinball-style: emits one `newmtl` block per call, with
+/// duplicates. When `state.dedup_mtl_blocks` is set, only the first
+/// occurrence of each `(material, texture)` pair is written; subsequent
+/// calls still resolve the on-disk image (so it gets extracted) but
+/// skip the MTL block. The `usemtl` reference in the OBJ remains the
+/// same sanitized name and resolves to the first-emitted block.
 fn emit_mtl_block<M: MtlWriter<f32>>(
     mtl: &mut M,
     state: &mut WriterState,
@@ -1057,11 +1104,24 @@ fn emit_mtl_block<M: MtlWriter<f32>>(
     let mtl_name = sanitize_material_name(material_name);
 
     // Resolve the on-disk image filename and ensure the file is written.
+    // We do this whether or not we're about to skip the MTL block, so
+    // the `images/` folder stays complete in dedup mode too.
     let map_path = if let Some(name) = texture_name {
         ensure_image_written(state, fs, name)?
     } else {
         None
     };
+
+    if state.dedup_mtl_blocks {
+        let key = (
+            material_name.to_string(),
+            texture_name.unwrap_or("").to_string(),
+        );
+        if !state.seen_mtl_pairs.insert(key) {
+            // Pair already emitted - skip this newmtl block.
+            return Ok(mtl_name);
+        }
+    }
 
     write_mtl_block(mtl, state, &mtl_name, material_name, map_path.as_deref())?;
     Ok(mtl_name)
@@ -1217,4 +1277,48 @@ fn write_image_bmp(
         .write_to(&mut buffer, image::ImageFormat::Bmp)
         .map_err(|e| io::Error::other(format!("Failed to encode BMP {}: {e}", path.display())))?;
     fs.write_file(path, buffer.get_ref())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::filesystem::MemoryFileSystem;
+
+    fn export_to_memory(options: &ObjExportOptions) -> (String, String) {
+        let vpx = VPX::default();
+        let fs = MemoryFileSystem::default();
+        let obj_path = Path::new("out/test.obj");
+        export_obj(&vpx, obj_path, &fs, options).unwrap();
+        let obj = String::from_utf8(fs.read_file(obj_path).unwrap()).unwrap();
+        let mtl =
+            String::from_utf8(fs.read_file(&obj_path.with_extension("mtl")).unwrap()).unwrap();
+        (obj, mtl)
+    }
+
+    #[test]
+    fn default_options_emit_one_newmtl_per_usemtl() {
+        // VPinball-faithful default: each `usemtl` gets a `newmtl`.
+        let (obj, mtl) = export_to_memory(&ObjExportOptions::default());
+        let usemtl = obj.matches("usemtl ").count();
+        let newmtl = mtl.matches("newmtl ").count();
+        assert!(usemtl > 0);
+        assert_eq!(usemtl, newmtl);
+    }
+
+    #[test]
+    fn dedup_option_collapses_newmtl_blocks() {
+        // Same export with dedup on: at most one `newmtl` per unique
+        // material name, never more than `usemtl`. For the default VPX
+        // (single playfield material), both should collapse to 1.
+        let (obj, mtl) = export_to_memory(&ObjExportOptions {
+            dedup_mtl_blocks: true,
+        });
+        let usemtl = obj.matches("usemtl ").count();
+        let newmtl = mtl.matches("newmtl ").count();
+        assert!(usemtl >= 1);
+        assert!(
+            newmtl <= usemtl,
+            "newmtl ({newmtl}) should not exceed usemtl ({usemtl}) when deduped"
+        );
+    }
 }

--- a/src/vpx/export/obj_export.rs
+++ b/src/vpx/export/obj_export.rs
@@ -250,7 +250,10 @@ fn write_playfield<O: ObjWriter<f32>, M: MtlWriter<f32>>(
         state,
         fs,
         Block {
-            name: "playfield_mesh",
+            // VPinball's PinTable::ExportMesh emits `o <m_wzName>` for the
+            // playfield quad (default "Table1" if the user never renamed
+            // the table).
+            name: &state.vpx.gamedata.name,
             vertices: &vertices,
             indices: &indices,
             translation: Vec3::new(0.0, 0.0, 0.0),
@@ -416,64 +419,106 @@ fn write_wall<O: ObjWriter<f32>, M: MtlWriter<f32>>(
         return Ok(());
     };
 
-    if wall.is_top_bottom_visible
-        && let Some((vertices, indices)) = meshes.top
-    {
-        let material_name = if !wall.top_material.is_empty() {
-            Some(wall.top_material.clone())
-        } else {
-            None
-        };
-        let texture_name = if !wall.image.is_empty() {
-            Some(wall.image.clone())
-        } else {
-            None
-        };
-        write_block(
-            obj,
-            mtl,
-            state,
-            fs,
-            Block {
-                name: &format!("{}Top", wall.name),
-                vertices: &vertices,
-                indices: &indices,
-                translation: Vec3::new(0.0, 0.0, 0.0),
-                material_name: material_name.as_deref(),
-                texture_name: texture_name.as_deref(),
-                smoothing: true,
-            },
-        )?;
-    }
-
-    if wall.is_side_visible
-        && let Some((vertices, indices)) = meshes.side
-    {
-        let material_name = if !wall.side_material.is_empty() {
-            Some(wall.side_material.clone())
-        } else {
-            None
-        };
-        let texture_name = if !wall.side_image.is_empty() {
-            Some(wall.side_image.clone())
-        } else {
-            None
-        };
-        write_block(
-            obj,
-            mtl,
-            state,
-            fs,
-            Block {
-                name: &format!("{}Side", wall.name),
-                vertices: &vertices,
-                indices: &indices,
-                translation: Vec3::new(0.0, 0.0, 0.0),
-                material_name: material_name.as_deref(),
-                texture_name: texture_name.as_deref(),
-                smoothing: false,
-            },
-        )?;
+    // VPinball's `Surface::ExportMesh` (surface.cpp:675) has three branches:
+    //
+    //   - top-only:  one object `<name>`, top material, no smoothing group
+    //   - side-only: one object `<name>`, side material, no smoothing group
+    //   - both:      one object `<name>` with sideBuf*4 followed by topBuf*1,
+    //                top material + `s 1`, top face indices shifted by 4*N
+    //
+    // We mirror the same dispatch.
+    match (
+        wall.is_top_bottom_visible,
+        wall.is_side_visible,
+        meshes.top,
+        meshes.side,
+    ) {
+        (true, false, Some((vertices, indices)), _) => {
+            let material_name = if !wall.top_material.is_empty() {
+                Some(wall.top_material.clone())
+            } else {
+                None
+            };
+            let texture_name = if !wall.image.is_empty() {
+                Some(wall.image.clone())
+            } else {
+                None
+            };
+            write_block(
+                obj,
+                mtl,
+                state,
+                fs,
+                Block {
+                    name: &wall.name,
+                    vertices: &vertices,
+                    indices: &indices,
+                    translation: Vec3::new(0.0, 0.0, 0.0),
+                    material_name: material_name.as_deref(),
+                    texture_name: texture_name.as_deref(),
+                    smoothing: false,
+                },
+            )?;
+        }
+        (false, true, _, Some((vertices, indices))) => {
+            let material_name = if !wall.side_material.is_empty() {
+                Some(wall.side_material.clone())
+            } else {
+                None
+            };
+            let texture_name = if !wall.side_image.is_empty() {
+                Some(wall.side_image.clone())
+            } else {
+                None
+            };
+            write_block(
+                obj,
+                mtl,
+                state,
+                fs,
+                Block {
+                    name: &wall.name,
+                    vertices: &vertices,
+                    indices: &indices,
+                    translation: Vec3::new(0.0, 0.0, 0.0),
+                    material_name: material_name.as_deref(),
+                    texture_name: texture_name.as_deref(),
+                    smoothing: false,
+                },
+            )?;
+        }
+        (true, true, Some((top_v, top_i)), Some((side_v, side_i))) => {
+            let side_count = side_v.len() as i64;
+            let mut combined_v = side_v;
+            combined_v.extend(top_v);
+            let mut combined_i = side_i;
+            combined_i.extend(top_i.into_iter().map(|f| VpxFace {
+                i0: f.i0 + side_count,
+                i1: f.i1 + side_count,
+                i2: f.i2 + side_count,
+            }));
+            let material_name = if !wall.top_material.is_empty() {
+                Some(wall.top_material.clone())
+            } else {
+                None
+            };
+            write_block(
+                obj,
+                mtl,
+                state,
+                fs,
+                Block {
+                    name: &wall.name,
+                    vertices: &combined_v,
+                    indices: &combined_i,
+                    translation: Vec3::new(0.0, 0.0, 0.0),
+                    material_name: material_name.as_deref(),
+                    texture_name: None,
+                    smoothing: true,
+                },
+            )?;
+        }
+        _ => {}
     }
     Ok(())
 }

--- a/src/vpx/export/obj_export.rs
+++ b/src/vpx/export/obj_export.rs
@@ -39,9 +39,9 @@ use crate::vpx::image::ImageData;
 use crate::vpx::material::{Material, MaterialType};
 use crate::vpx::math::{Matrix3D, Vec3, Vertex3D};
 use crate::vpx::mesh::bumpers::build_bumper_meshes;
-use crate::vpx::mesh::flippers::build_flipper_meshes;
-use crate::vpx::mesh::gates::build_gate_meshes;
-use crate::vpx::mesh::hittargets::build_hit_target_mesh;
+use crate::vpx::mesh::flippers::build_flipper_meshes_unchecked;
+use crate::vpx::mesh::gates::build_gate_meshes_unchecked;
+use crate::vpx::mesh::hittargets::build_hit_target_mesh_unchecked;
 use crate::vpx::mesh::kickers::build_kicker_meshes;
 use crate::vpx::mesh::playfields::build_playfield_mesh;
 use crate::vpx::mesh::ramps::build_ramp_mesh;
@@ -717,10 +717,8 @@ fn write_flipper<O: ObjWriter<f32>, M: MtlWriter<f32>>(
     fs: &dyn FileSystem,
     flipper: &crate::vpx::gameitem::flipper::Flipper,
 ) -> io::Result<()> {
-    if !flipper.is_visible {
-        return Ok(());
-    }
-    let Some(meshes) = build_flipper_meshes(flipper, 0.0) else {
+    // VPinball's `Flipper::ExportMesh` has no `m_d.m_visible` guard.
+    let Some(meshes) = build_flipper_meshes_unchecked(flipper, 0.0) else {
         return Ok(());
     };
     let translation = meshes.center;
@@ -780,12 +778,10 @@ fn write_gate<O: ObjWriter<f32>, M: MtlWriter<f32>>(
     fs: &dyn FileSystem,
     gate: &crate::vpx::gameitem::gate::Gate,
 ) -> io::Result<()> {
-    if !gate.is_visible {
-        return Ok(());
-    }
+    // VPinball's `Gate::ExportMesh` has no `m_d.m_visible` guard.
     let surface_height = state.surface_height(&gate.surface, gate.center.x, gate.center.y);
     let translation = Vec3::new(gate.center.x, gate.center.y, surface_height + gate.height);
-    let Some(meshes) = build_gate_meshes(gate) else {
+    let Some(meshes) = build_gate_meshes_unchecked(gate) else {
         return Ok(());
     };
     let material_name = if gate.material.is_empty() {
@@ -893,9 +889,7 @@ fn write_spinner<O: ObjWriter<f32>, M: MtlWriter<f32>>(
     fs: &dyn FileSystem,
     spinner: &crate::vpx::gameitem::spinner::Spinner,
 ) -> io::Result<()> {
-    if !spinner.is_visible {
-        return Ok(());
-    }
+    // VPinball's `Spinner::ExportMesh` has no `m_d.m_visible` guard.
     let surface_height = state.surface_height(&spinner.surface, spinner.center.x, spinner.center.y);
     let translation = Vec3::new(
         spinner.center.x,
@@ -955,10 +949,8 @@ fn write_hittarget<O: ObjWriter<f32>, M: MtlWriter<f32>>(
     fs: &dyn FileSystem,
     target: &crate::vpx::gameitem::hittarget::HitTarget,
 ) -> io::Result<()> {
-    if !target.is_visible {
-        return Ok(());
-    }
-    let Some((vertices, indices)) = build_hit_target_mesh(target) else {
+    // VPinball's `HitTarget::ExportMesh` has no `m_d.m_visible` guard.
+    let Some((vertices, indices)) = build_hit_target_mesh_unchecked(target) else {
         return Ok(());
     };
     let translation = Vec3::new(target.position.x, target.position.y, target.position.z);

--- a/src/vpx/export/obj_export.rs
+++ b/src/vpx/export/obj_export.rs
@@ -1,0 +1,1267 @@
+//! Wavefront OBJ export of an entire VPX table.
+//!
+//! Mirrors VPinball's `File -> Export -> OBJ Mesh`: produces a single `.obj`
+//! file with one `o` block per item (playfield + every visible game item),
+//! a single `.mtl` file with one `newmtl` block per unique
+//! `(material, texture)` pair encountered, and an `images/` sibling folder
+//! containing the texture files referenced from the `.mtl`.
+//!
+//! Output layout, given `path/to/<stem>.obj`:
+//!
+//! ```text
+//! path/to/
+//! +-- <stem>.obj
+//! +-- <stem>.mtl
+//! +-- images/
+//!     +-- <texture-name>.<ext>
+//! ```
+//!
+//! Coordinate convention matches VPinball's `ObjLoader`:
+//!
+//! - `obj_x = vpx_x + tx`, `obj_y = vpx_y + ty`, `obj_z = -(vpx_z + tz)`
+//! - `obj_v = 1 - vpx_tv`
+//! - normals' Z is negated (`obj_nz = -vpx_nz`)
+//! - triangle winding is reversed (`(i0, i1, i2)` is emitted as `f i2 i1 i0`)
+//! - NaN normals/UVs are written as 0
+//!
+//! The walk only includes the items that VPinball's `Item::ExportMesh`
+//! implementations cover (primitive, wall, ramp, rubber, bumper, flipper,
+//! gate, kicker, spinner, hittarget, trigger). Lights, decals, plungers,
+//! flashers and reels are skipped, matching VPinball.
+
+use crate::filesystem::FileSystem;
+use crate::vpx::TableDimensions;
+use crate::vpx::VPX;
+use crate::vpx::expanded::util::sanitize_filename;
+use crate::vpx::gameitem::GameItemEnum;
+use crate::vpx::gameitem::primitive::{Primitive, VertexWrapper};
+use crate::vpx::image::ImageData;
+use crate::vpx::material::{Material, MaterialType};
+use crate::vpx::math::{Matrix3D, Vec3, Vertex3D};
+use crate::vpx::mesh::bumpers::build_bumper_meshes;
+use crate::vpx::mesh::flippers::build_flipper_meshes;
+use crate::vpx::mesh::gates::build_gate_meshes;
+use crate::vpx::mesh::hittargets::build_hit_target_mesh;
+use crate::vpx::mesh::kickers::build_kicker_meshes;
+use crate::vpx::mesh::playfields::build_playfield_mesh;
+use crate::vpx::mesh::ramps::build_ramp_mesh;
+use crate::vpx::mesh::rubbers::build_rubber_mesh;
+use crate::vpx::mesh::spinners::build_spinner_meshes;
+use crate::vpx::mesh::triggers::build_trigger_mesh;
+use crate::vpx::mesh::walls::build_wall_meshes;
+use crate::vpx::obj::VpxFace;
+use log::{info, warn};
+use std::collections::{HashMap, HashSet};
+use std::io;
+use std::path::{Path, PathBuf};
+use wavefront_obj_io::{IoMtlWriter, IoObjWriter, MapKind, MtlWriter, ObjWriter, SmoothingGroup};
+
+/// Export the entire VPX table as a Wavefront OBJ + companion MTL + images
+/// folder.
+///
+/// Writes `<obj_path>` (the OBJ), `<obj_path>.with_extension("mtl")` (the
+/// material library), and `<obj_path-parent>/images/<image>.<ext>` for every
+/// texture referenced by the exported items.
+///
+/// # Example
+/// ```no_run
+/// use std::path::Path;
+/// use vpin::filesystem::RealFileSystem;
+/// use vpin::vpx;
+/// use vpin::vpx::export::obj_export::export_obj;
+///
+/// let vpx = vpx::read(Path::new("table.vpx")).unwrap();
+/// export_obj(&vpx, Path::new("table_export/table.obj"), &RealFileSystem).unwrap();
+/// ```
+pub fn export_obj(vpx: &VPX, obj_path: &Path, fs: &dyn FileSystem) -> io::Result<()> {
+    let dir = obj_path
+        .parent()
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "obj_path has no parent"))?;
+    fs.create_dir_all(dir)?;
+
+    let mtl_path = obj_path.with_extension("mtl");
+    let mtl_filename = mtl_path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "mtl path has no filename"))?
+        .to_string();
+
+    let images_dir = dir.join("images");
+
+    let mut obj_buf: Vec<u8> = Vec::new();
+    let mut mtl_buf: Vec<u8> = Vec::new();
+    {
+        let mut obj_writer: IoObjWriter<_, f32> = IoObjWriter::new(&mut obj_buf);
+        let mut mtl_writer: IoMtlWriter<_, f32> = IoMtlWriter::new(&mut mtl_buf);
+
+        obj_writer.write_comment("VPin table OBJ file")?;
+        obj_writer.write_material_lib(&[mtl_filename.as_str()])?;
+        mtl_writer.write_comment("VPin table mat file")?;
+
+        let mut state = WriterState::new(vpx, &images_dir);
+
+        // 1. Implicit playfield quad (always emitted, matches VPinball
+        //    PinTable::ExportMesh).
+        write_playfield(&mut obj_writer, &mut mtl_writer, &mut state, fs)?;
+
+        // 2. Walk gameitems in storage order (mirrors VPinball's m_vedit
+        //    iteration). Visibility filter only - the m_desktopBackdrop bit
+        //    is not yet parsed by vpin and is irrelevant for items with
+        //    geometry (they all assert !m_desktopBackdrop in VPinball).
+        for gameitem in &vpx.gameitems {
+            write_gameitem(&mut obj_writer, &mut mtl_writer, &mut state, fs, gameitem)?;
+        }
+    }
+
+    fs.write_file(obj_path, &obj_buf)?;
+    fs.write_file(&mtl_path, &mtl_buf)?;
+    info!(
+        "Exported OBJ to {} ({} bytes), MTL to {} ({} bytes)",
+        obj_path.display(),
+        obj_buf.len(),
+        mtl_path.display(),
+        mtl_buf.len(),
+    );
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// State threaded through the walk.
+// ---------------------------------------------------------------------------
+
+struct WriterState<'a> {
+    vpx: &'a VPX,
+    images_dir: PathBuf,
+    table_dims: TableDimensions,
+    /// VPinball's `GetDetailLevel()` - either the table's
+    /// `user_detail_level` or the editor default. Drives ramp/rubber
+    /// segment counts via `vpinball_ring_segments`.
+    detail_level: u32,
+    /// Running vertex offset for face indices. VPinball calls this
+    /// `m_faceIndexOffset` and bumps it after each item by the number of
+    /// vertices written.
+    face_offset: u32,
+    /// `(material_name, texture_name)` pairs that already have a `newmtl`
+    /// block emitted. Texture name is empty when the material has no image.
+    seen_mtl_pairs: HashSet<(String, String)>,
+    /// Mapping from VPX image name (case-preserving) to the on-disk file
+    /// name inside `images/`. Populated lazily as textures are referenced.
+    image_filenames: HashMap<String, String>,
+    /// Lowercased image filenames already taken inside `images/`. Used to
+    /// detect collisions on case-insensitive filesystems and append a
+    /// `_dedup<n>` suffix, mirroring `expanded::images::write_images`.
+    used_lower_filenames: HashSet<String>,
+    image_dedup_counter: u32,
+    /// VPX image names already written to disk. Skip subsequent encounters.
+    images_written: HashSet<String>,
+}
+
+impl<'a> WriterState<'a> {
+    fn new(vpx: &'a VPX, images_dir: &Path) -> Self {
+        Self {
+            vpx,
+            images_dir: images_dir.to_path_buf(),
+            table_dims: TableDimensions::new(
+                vpx.gamedata.left,
+                vpx.gamedata.top,
+                vpx.gamedata.right,
+                vpx.gamedata.bottom,
+            ),
+            detail_level: vpx.gamedata.effective_detail_level(),
+            face_offset: 0,
+            seen_mtl_pairs: HashSet::new(),
+            image_filenames: HashMap::new(),
+            used_lower_filenames: HashSet::new(),
+            image_dedup_counter: 0,
+            images_written: HashSet::new(),
+        }
+    }
+
+    fn material_by_name(&self, name: &str) -> Option<&Material> {
+        if name.is_empty() {
+            return None;
+        }
+        if let Some(ref mats) = self.vpx.gamedata.materials {
+            return mats.iter().find(|m| m.name.eq_ignore_ascii_case(name));
+        }
+        None
+    }
+
+    fn image_by_name(&self, name: &str) -> Option<&ImageData> {
+        if name.is_empty() {
+            return None;
+        }
+        self.vpx
+            .images
+            .iter()
+            .find(|img| img.name.eq_ignore_ascii_case(name))
+    }
+
+    fn surface_height(&self, surface_name: &str, x: f32, y: f32) -> f32 {
+        if surface_name.is_empty() {
+            return 0.0;
+        }
+        for item in &self.vpx.gameitems {
+            match item {
+                GameItemEnum::Wall(wall) if wall.name.eq_ignore_ascii_case(surface_name) => {
+                    return wall.height_top;
+                }
+                GameItemEnum::Ramp(ramp) if ramp.name.eq_ignore_ascii_case(surface_name) => {
+                    return crate::vpx::mesh::ramps::get_ramp_surface_height(ramp, x, y);
+                }
+                _ => {}
+            }
+        }
+        0.0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Per-item dispatch.
+// ---------------------------------------------------------------------------
+
+fn write_playfield<O: ObjWriter<f32>, M: MtlWriter<f32>>(
+    obj: &mut O,
+    mtl: &mut M,
+    state: &mut WriterState,
+    fs: &dyn FileSystem,
+) -> io::Result<()> {
+    let (vertices, indices) = build_playfield_mesh(
+        state.vpx.gamedata.left,
+        state.vpx.gamedata.top,
+        state.vpx.gamedata.right,
+        state.vpx.gamedata.bottom,
+    );
+
+    let material_name = if state.vpx.gamedata.playfield_material.is_empty() {
+        None
+    } else {
+        Some(state.vpx.gamedata.playfield_material.clone())
+    };
+    let texture_name = if state.vpx.gamedata.image.is_empty() {
+        None
+    } else {
+        Some(state.vpx.gamedata.image.clone())
+    };
+
+    write_block(
+        obj,
+        mtl,
+        state,
+        fs,
+        Block {
+            name: "playfield_mesh",
+            vertices: &vertices,
+            indices: &indices,
+            translation: Vec3::new(0.0, 0.0, 0.0),
+            material_name: material_name.as_deref(),
+            texture_name: texture_name.as_deref(),
+            smoothing: true,
+        },
+    )
+}
+
+fn write_gameitem<O: ObjWriter<f32>, M: MtlWriter<f32>>(
+    obj: &mut O,
+    mtl: &mut M,
+    state: &mut WriterState,
+    fs: &dyn FileSystem,
+    item: &GameItemEnum,
+) -> io::Result<()> {
+    match item {
+        GameItemEnum::Primitive(primitive) => write_primitive(obj, mtl, state, fs, primitive),
+        GameItemEnum::Wall(wall) => write_wall(obj, mtl, state, fs, wall),
+        GameItemEnum::Ramp(ramp) => write_ramp(obj, mtl, state, fs, ramp),
+        GameItemEnum::Rubber(rubber) => write_rubber(obj, mtl, state, fs, rubber),
+        GameItemEnum::Bumper(bumper) => write_bumper(obj, mtl, state, fs, bumper),
+        GameItemEnum::Flipper(flipper) => write_flipper(obj, mtl, state, fs, flipper),
+        GameItemEnum::Gate(gate) => write_gate(obj, mtl, state, fs, gate),
+        GameItemEnum::Kicker(kicker) => write_kicker(obj, mtl, state, fs, kicker),
+        GameItemEnum::Spinner(spinner) => write_spinner(obj, mtl, state, fs, spinner),
+        GameItemEnum::HitTarget(hit_target) => write_hittarget(obj, mtl, state, fs, hit_target),
+        GameItemEnum::Trigger(trigger) => write_trigger(obj, mtl, state, fs, trigger),
+        // Items VPinball does not include in OBJ export.
+        GameItemEnum::Light(_)
+        | GameItemEnum::Decal(_)
+        | GameItemEnum::Plunger(_)
+        | GameItemEnum::Flasher(_)
+        | GameItemEnum::Reel(_)
+        | GameItemEnum::Timer(_)
+        | GameItemEnum::TextBox(_)
+        | GameItemEnum::LightSequencer(_)
+        | GameItemEnum::PartGroup(_)
+        | GameItemEnum::Ball(_)
+        | GameItemEnum::Generic(_, _) => Ok(()),
+    }
+}
+
+fn write_primitive<O: ObjWriter<f32>, M: MtlWriter<f32>>(
+    obj: &mut O,
+    mtl: &mut M,
+    state: &mut WriterState,
+    fs: &dyn FileSystem,
+    primitive: &Primitive,
+) -> io::Result<()> {
+    if !primitive.is_visible {
+        return Ok(());
+    }
+    let read = match primitive.read_mesh() {
+        Ok(Some(read)) => read,
+        Ok(None) => return Ok(()),
+        Err(e) => {
+            warn!(
+                "Skipping primitive '{}' due to mesh read error: {e}",
+                primitive.name
+            );
+            return Ok(());
+        }
+    };
+
+    let world_matrix = primitive_world_matrix(primitive);
+    let vertices: Vec<VertexWrapper> = read
+        .vertices
+        .into_iter()
+        .map(|mut vw| {
+            let v = Vertex3D::new(vw.vertex.x, vw.vertex.y, vw.vertex.z);
+            let transformed = world_matrix.transform_vertex(v);
+            vw.vertex.x = transformed.x;
+            vw.vertex.y = transformed.y;
+            vw.vertex.z = transformed.z;
+
+            if !vw.vertex.nx.is_nan() && !vw.vertex.ny.is_nan() && !vw.vertex.nz.is_nan() {
+                let n = world_matrix.transform_normal(vw.vertex.nx, vw.vertex.ny, vw.vertex.nz);
+                let len = (n.x * n.x + n.y * n.y + n.z * n.z).sqrt();
+                if len > 0.0 {
+                    vw.vertex.nx = n.x / len;
+                    vw.vertex.ny = n.y / len;
+                    vw.vertex.nz = n.z / len;
+                }
+            }
+            vw
+        })
+        .collect();
+
+    // Playfield primitives in VPinball pull material/image from gamedata,
+    // not from the primitive's own fields.
+    let (material_name, texture_name) = if primitive.is_playfield() {
+        let m = if state.vpx.gamedata.playfield_material.is_empty() {
+            None
+        } else {
+            Some(state.vpx.gamedata.playfield_material.clone())
+        };
+        let t = if state.vpx.gamedata.image.is_empty() {
+            None
+        } else {
+            Some(state.vpx.gamedata.image.clone())
+        };
+        (m, t)
+    } else {
+        let m = if primitive.material.is_empty() {
+            None
+        } else {
+            Some(primitive.material.clone())
+        };
+        let t = if primitive.image.is_empty() {
+            None
+        } else {
+            Some(primitive.image.clone())
+        };
+        (m, t)
+    };
+
+    write_block(
+        obj,
+        mtl,
+        state,
+        fs,
+        Block {
+            name: &primitive.name,
+            vertices: &vertices,
+            indices: &read.indices,
+            translation: Vec3::new(0.0, 0.0, 0.0),
+            material_name: material_name.as_deref(),
+            texture_name: texture_name.as_deref(),
+            smoothing: false,
+        },
+    )
+}
+
+/// Compose the full vpx-space world matrix for a primitive, including the
+/// position translation that VPinball folds into `m_fullMatrix` for
+/// `Primitive::ExportMesh`.
+fn primitive_world_matrix(primitive: &Primitive) -> Matrix3D {
+    let pos = &primitive.position;
+    let size = &primitive.size;
+    let rot = &primitive.rot_and_tra;
+
+    let rt = Matrix3D::translate(rot[3], rot[4], rot[5])
+        * Matrix3D::rotate_z(rot[2].to_radians())
+        * Matrix3D::rotate_y(rot[1].to_radians())
+        * Matrix3D::rotate_x(rot[0].to_radians())
+        * Matrix3D::rotate_z(rot[8].to_radians())
+        * Matrix3D::rotate_y(rot[7].to_radians())
+        * Matrix3D::rotate_x(rot[6].to_radians());
+
+    Matrix3D::translate(pos.x, pos.y, pos.z) * Matrix3D::scale(size.x, size.y, size.z) * rt
+}
+
+fn write_wall<O: ObjWriter<f32>, M: MtlWriter<f32>>(
+    obj: &mut O,
+    mtl: &mut M,
+    state: &mut WriterState,
+    fs: &dyn FileSystem,
+    wall: &crate::vpx::gameitem::wall::Wall,
+) -> io::Result<()> {
+    let Some(meshes) = build_wall_meshes(wall, &state.table_dims) else {
+        return Ok(());
+    };
+
+    if wall.is_top_bottom_visible
+        && let Some((vertices, indices)) = meshes.top
+    {
+        let material_name = if !wall.top_material.is_empty() {
+            Some(wall.top_material.clone())
+        } else {
+            None
+        };
+        let texture_name = if !wall.image.is_empty() {
+            Some(wall.image.clone())
+        } else {
+            None
+        };
+        write_block(
+            obj,
+            mtl,
+            state,
+            fs,
+            Block {
+                name: &format!("{}Top", wall.name),
+                vertices: &vertices,
+                indices: &indices,
+                translation: Vec3::new(0.0, 0.0, 0.0),
+                material_name: material_name.as_deref(),
+                texture_name: texture_name.as_deref(),
+                smoothing: true,
+            },
+        )?;
+    }
+
+    if wall.is_side_visible
+        && let Some((vertices, indices)) = meshes.side
+    {
+        let material_name = if !wall.side_material.is_empty() {
+            Some(wall.side_material.clone())
+        } else {
+            None
+        };
+        let texture_name = if !wall.side_image.is_empty() {
+            Some(wall.side_image.clone())
+        } else {
+            None
+        };
+        write_block(
+            obj,
+            mtl,
+            state,
+            fs,
+            Block {
+                name: &format!("{}Side", wall.name),
+                vertices: &vertices,
+                indices: &indices,
+                translation: Vec3::new(0.0, 0.0, 0.0),
+                material_name: material_name.as_deref(),
+                texture_name: texture_name.as_deref(),
+                smoothing: false,
+            },
+        )?;
+    }
+    Ok(())
+}
+
+fn write_ramp<O: ObjWriter<f32>, M: MtlWriter<f32>>(
+    obj: &mut O,
+    mtl: &mut M,
+    state: &mut WriterState,
+    fs: &dyn FileSystem,
+    ramp: &crate::vpx::gameitem::ramp::Ramp,
+) -> io::Result<()> {
+    if !ramp.is_visible {
+        return Ok(());
+    }
+    // VPinball's `Ramp::GenerateWireMesh` uses max-precision wire
+    // segments when the material is opaque (`!mat->m_bOpacityActive`).
+    // Missing/empty material falls through to opaque (vpinball's dummy
+    // material defaults `m_bOpacityActive = false`).
+    let material_opacity_active = state
+        .material_by_name(&ramp.material)
+        .is_some_and(|m| m.opacity_active);
+    let Some((vertices, indices)) = build_ramp_mesh(
+        ramp,
+        &state.table_dims,
+        state.detail_level,
+        material_opacity_active,
+    ) else {
+        return Ok(());
+    };
+    let material_name = if ramp.material.is_empty() {
+        None
+    } else {
+        Some(ramp.material.clone())
+    };
+    let texture_name = if ramp.image.is_empty() {
+        None
+    } else {
+        Some(ramp.image.clone())
+    };
+    write_block(
+        obj,
+        mtl,
+        state,
+        fs,
+        Block {
+            name: &ramp.name,
+            vertices: &vertices,
+            indices: &indices,
+            translation: Vec3::new(0.0, 0.0, 0.0),
+            material_name: material_name.as_deref(),
+            texture_name: texture_name.as_deref(),
+            smoothing: true,
+        },
+    )
+}
+
+fn write_rubber<O: ObjWriter<f32>, M: MtlWriter<f32>>(
+    obj: &mut O,
+    mtl: &mut M,
+    state: &mut WriterState,
+    fs: &dyn FileSystem,
+    rubber: &crate::vpx::gameitem::rubber::Rubber,
+) -> io::Result<()> {
+    if !rubber.is_visible {
+        return Ok(());
+    }
+    let Some((vertices, indices, center)) = build_rubber_mesh(rubber, state.detail_level) else {
+        return Ok(());
+    };
+    let material_name = if rubber.material.is_empty() {
+        None
+    } else {
+        Some(rubber.material.clone())
+    };
+    write_block(
+        obj,
+        mtl,
+        state,
+        fs,
+        Block {
+            name: &rubber.name,
+            vertices: &vertices,
+            indices: &indices,
+            translation: center,
+            material_name: material_name.as_deref(),
+            texture_name: None,
+            smoothing: true,
+        },
+    )
+}
+
+fn write_bumper<O: ObjWriter<f32>, M: MtlWriter<f32>>(
+    obj: &mut O,
+    mtl: &mut M,
+    state: &mut WriterState,
+    fs: &dyn FileSystem,
+    bumper: &crate::vpx::gameitem::bumper::Bumper,
+) -> io::Result<()> {
+    let surface_height = state.surface_height(&bumper.surface, bumper.center.x, bumper.center.y);
+    let translation = Vec3::new(bumper.center.x, bumper.center.y, surface_height);
+    let meshes = build_bumper_meshes(bumper);
+
+    if let Some((vertices, indices)) = meshes.base {
+        let material_name = if bumper.base_material.is_empty() {
+            None
+        } else {
+            Some(bumper.base_material.clone())
+        };
+        write_block(
+            obj,
+            mtl,
+            state,
+            fs,
+            Block {
+                name: &format!("{}Base", bumper.name),
+                vertices: &vertices,
+                indices: &indices,
+                translation,
+                material_name: material_name.as_deref(),
+                texture_name: None,
+                smoothing: true,
+            },
+        )?;
+    }
+    if let Some((vertices, indices)) = meshes.ring {
+        write_block(
+            obj,
+            mtl,
+            state,
+            fs,
+            Block {
+                name: &format!("{}Ring", bumper.name),
+                vertices: &vertices,
+                indices: &indices,
+                translation,
+                // VPinball calls WriteFaceInfoList without WriteMaterial for
+                // the ring (carries over the previous material). We don't
+                // emit usemtl here either.
+                material_name: None,
+                texture_name: None,
+                smoothing: true,
+            },
+        )?;
+    }
+    if let Some((vertices, indices)) = meshes.socket {
+        let material_name = if bumper.socket_material.is_empty() {
+            None
+        } else {
+            Some(bumper.socket_material.clone())
+        };
+        write_block(
+            obj,
+            mtl,
+            state,
+            fs,
+            Block {
+                name: &format!("{}Skirt", bumper.name),
+                vertices: &vertices,
+                indices: &indices,
+                translation,
+                material_name: material_name.as_deref(),
+                texture_name: None,
+                smoothing: true,
+            },
+        )?;
+    }
+    if let Some((vertices, indices)) = meshes.cap {
+        let material_name = if bumper.cap_material.is_empty() {
+            None
+        } else {
+            Some(bumper.cap_material.clone())
+        };
+        write_block(
+            obj,
+            mtl,
+            state,
+            fs,
+            Block {
+                name: &format!("{}Cap", bumper.name),
+                vertices: &vertices,
+                indices: &indices,
+                translation,
+                material_name: material_name.as_deref(),
+                texture_name: None,
+                smoothing: true,
+            },
+        )?;
+    }
+    Ok(())
+}
+
+fn write_flipper<O: ObjWriter<f32>, M: MtlWriter<f32>>(
+    obj: &mut O,
+    mtl: &mut M,
+    state: &mut WriterState,
+    fs: &dyn FileSystem,
+    flipper: &crate::vpx::gameitem::flipper::Flipper,
+) -> io::Result<()> {
+    if !flipper.is_visible {
+        return Ok(());
+    }
+    let Some(meshes) = build_flipper_meshes(flipper, 0.0) else {
+        return Ok(());
+    };
+    let translation = meshes.center;
+
+    let (base_vertices, base_indices) = meshes.base;
+    let base_material = if flipper.material.is_empty() {
+        None
+    } else {
+        Some(flipper.material.clone())
+    };
+    let base_texture = flipper.image.as_ref().filter(|s| !s.is_empty()).cloned();
+    write_block(
+        obj,
+        mtl,
+        state,
+        fs,
+        Block {
+            name: &format!("{}Base", flipper.name),
+            vertices: &base_vertices,
+            indices: &base_indices,
+            translation,
+            material_name: base_material.as_deref(),
+            texture_name: base_texture.as_deref(),
+            smoothing: true,
+        },
+    )?;
+
+    if let Some((rubber_vertices, rubber_indices)) = meshes.rubber {
+        let rubber_material = if flipper.rubber_material.is_empty() {
+            None
+        } else {
+            Some(flipper.rubber_material.clone())
+        };
+        write_block(
+            obj,
+            mtl,
+            state,
+            fs,
+            Block {
+                name: &format!("{}Rubber", flipper.name),
+                vertices: &rubber_vertices,
+                indices: &rubber_indices,
+                translation,
+                material_name: rubber_material.as_deref(),
+                texture_name: None,
+                smoothing: true,
+            },
+        )?;
+    }
+    Ok(())
+}
+
+fn write_gate<O: ObjWriter<f32>, M: MtlWriter<f32>>(
+    obj: &mut O,
+    mtl: &mut M,
+    state: &mut WriterState,
+    fs: &dyn FileSystem,
+    gate: &crate::vpx::gameitem::gate::Gate,
+) -> io::Result<()> {
+    if !gate.is_visible {
+        return Ok(());
+    }
+    let surface_height = state.surface_height(&gate.surface, gate.center.x, gate.center.y);
+    let translation = Vec3::new(gate.center.x, gate.center.y, surface_height + gate.height);
+    let Some(meshes) = build_gate_meshes(gate) else {
+        return Ok(());
+    };
+    let material_name = if gate.material.is_empty() {
+        None
+    } else {
+        Some(gate.material.clone())
+    };
+    if let Some((vertices, indices)) = meshes.bracket {
+        write_block(
+            obj,
+            mtl,
+            state,
+            fs,
+            Block {
+                name: &format!("{}Bracket", gate.name),
+                vertices: &vertices,
+                indices: &indices,
+                translation,
+                material_name: material_name.as_deref(),
+                texture_name: None,
+                smoothing: true,
+            },
+        )?;
+    }
+    let (vertices, indices) = meshes.wire;
+    write_block(
+        obj,
+        mtl,
+        state,
+        fs,
+        Block {
+            name: &format!("{}Wire", gate.name),
+            vertices: &vertices,
+            indices: &indices,
+            translation,
+            material_name: material_name.as_deref(),
+            texture_name: None,
+            smoothing: true,
+        },
+    )
+}
+
+fn write_kicker<O: ObjWriter<f32>, M: MtlWriter<f32>>(
+    obj: &mut O,
+    mtl: &mut M,
+    state: &mut WriterState,
+    fs: &dyn FileSystem,
+    kicker: &crate::vpx::gameitem::kicker::Kicker,
+) -> io::Result<()> {
+    if matches!(
+        kicker.kicker_type,
+        crate::vpx::gameitem::kicker::KickerType::Invisible
+    ) {
+        return Ok(());
+    }
+    let surface_height = state.surface_height(&kicker.surface, kicker.center.x, kicker.center.y);
+    let translation = Vec3::new(kicker.center.x, kicker.center.y, surface_height);
+    let meshes = build_kicker_meshes(kicker);
+    let material_name = if kicker.material.is_empty() {
+        None
+    } else {
+        Some(kicker.material.clone())
+    };
+    if let Some((vertices, indices)) = meshes.plate {
+        write_block(
+            obj,
+            mtl,
+            state,
+            fs,
+            Block {
+                name: &format!("{}Plate", kicker.name),
+                vertices: &vertices,
+                indices: &indices,
+                translation,
+                material_name: material_name.as_deref(),
+                texture_name: None,
+                smoothing: true,
+            },
+        )?;
+    }
+    if let Some((vertices, indices)) = meshes.kicker {
+        write_block(
+            obj,
+            mtl,
+            state,
+            fs,
+            Block {
+                name: &kicker.name,
+                vertices: &vertices,
+                indices: &indices,
+                translation,
+                material_name: material_name.as_deref(),
+                texture_name: None,
+                smoothing: true,
+            },
+        )?;
+    }
+    Ok(())
+}
+
+fn write_spinner<O: ObjWriter<f32>, M: MtlWriter<f32>>(
+    obj: &mut O,
+    mtl: &mut M,
+    state: &mut WriterState,
+    fs: &dyn FileSystem,
+    spinner: &crate::vpx::gameitem::spinner::Spinner,
+) -> io::Result<()> {
+    if !spinner.is_visible {
+        return Ok(());
+    }
+    let surface_height = state.surface_height(&spinner.surface, spinner.center.x, spinner.center.y);
+    let translation = Vec3::new(
+        spinner.center.x,
+        spinner.center.y,
+        surface_height + spinner.height,
+    );
+    let meshes = build_spinner_meshes(spinner);
+    if let Some((vertices, indices)) = meshes.bracket {
+        write_block(
+            obj,
+            mtl,
+            state,
+            fs,
+            Block {
+                name: &format!("{}Bracket", spinner.name),
+                vertices: &vertices,
+                indices: &indices,
+                translation,
+                material_name: None,
+                texture_name: None,
+                smoothing: true,
+            },
+        )?;
+    }
+    let (vertices, indices) = meshes.plate;
+    let material_name = if spinner.material.is_empty() {
+        None
+    } else {
+        Some(spinner.material.clone())
+    };
+    let texture_name = if spinner.image.is_empty() {
+        None
+    } else {
+        Some(spinner.image.clone())
+    };
+    write_block(
+        obj,
+        mtl,
+        state,
+        fs,
+        Block {
+            name: &format!("{}Plate", spinner.name),
+            vertices: &vertices,
+            indices: &indices,
+            translation,
+            material_name: material_name.as_deref(),
+            texture_name: texture_name.as_deref(),
+            smoothing: true,
+        },
+    )
+}
+
+fn write_hittarget<O: ObjWriter<f32>, M: MtlWriter<f32>>(
+    obj: &mut O,
+    mtl: &mut M,
+    state: &mut WriterState,
+    fs: &dyn FileSystem,
+    target: &crate::vpx::gameitem::hittarget::HitTarget,
+) -> io::Result<()> {
+    if !target.is_visible {
+        return Ok(());
+    }
+    let Some((vertices, indices)) = build_hit_target_mesh(target) else {
+        return Ok(());
+    };
+    let translation = Vec3::new(target.position.x, target.position.y, target.position.z);
+    let material_name = if target.material.is_empty() {
+        None
+    } else {
+        Some(target.material.clone())
+    };
+    let texture_name = if target.image.is_empty() {
+        None
+    } else {
+        Some(target.image.clone())
+    };
+    write_block(
+        obj,
+        mtl,
+        state,
+        fs,
+        Block {
+            name: &target.name,
+            vertices: &vertices,
+            indices: &indices,
+            translation,
+            material_name: material_name.as_deref(),
+            texture_name: texture_name.as_deref(),
+            smoothing: true,
+        },
+    )
+}
+
+fn write_trigger<O: ObjWriter<f32>, M: MtlWriter<f32>>(
+    obj: &mut O,
+    mtl: &mut M,
+    state: &mut WriterState,
+    fs: &dyn FileSystem,
+    trigger: &crate::vpx::gameitem::trigger::Trigger,
+) -> io::Result<()> {
+    if !trigger.is_visible {
+        return Ok(());
+    }
+    let surface_height = state.surface_height(&trigger.surface, trigger.center.x, trigger.center.y);
+    let translation = Vec3::new(trigger.center.x, trigger.center.y, surface_height);
+    let Some((vertices, indices)) = build_trigger_mesh(trigger) else {
+        return Ok(());
+    };
+    let material_name = if trigger.material.is_empty() {
+        None
+    } else {
+        Some(trigger.material.clone())
+    };
+    write_block(
+        obj,
+        mtl,
+        state,
+        fs,
+        Block {
+            name: &trigger.name,
+            vertices: &vertices,
+            indices: &indices,
+            translation,
+            material_name: material_name.as_deref(),
+            texture_name: None,
+            smoothing: true,
+        },
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Block writer + MTL/image emission.
+// ---------------------------------------------------------------------------
+
+struct Block<'a> {
+    name: &'a str,
+    vertices: &'a [VertexWrapper],
+    indices: &'a [VpxFace],
+    translation: Vec3,
+    material_name: Option<&'a str>,
+    texture_name: Option<&'a str>,
+    smoothing: bool,
+}
+
+fn write_block<O: ObjWriter<f32>, M: MtlWriter<f32>>(
+    obj: &mut O,
+    mtl: &mut M,
+    state: &mut WriterState,
+    fs: &dyn FileSystem,
+    block: Block,
+) -> io::Result<()> {
+    if block.vertices.is_empty() || block.indices.is_empty() {
+        return Ok(());
+    }
+
+    obj.write_object_name(block.name)?;
+
+    // Positions: world = local + translation; obj_z = -world_z
+    for vw in block.vertices {
+        let v = &vw.vertex;
+        let x = v.x + block.translation.x;
+        let y = v.y + block.translation.y;
+        let z = v.z + block.translation.z;
+        obj.write_vertex(x, y, -z, None)?;
+    }
+    // UVs: tv -> 1 - tv, NaN -> 0
+    for vw in block.vertices {
+        let tu = if vw.vertex.tu.is_nan() {
+            0.0
+        } else {
+            vw.vertex.tu
+        };
+        let tv = if vw.vertex.tv.is_nan() {
+            0.0
+        } else {
+            1.0 - vw.vertex.tv
+        };
+        obj.write_texture_coordinate(tu, Some(tv), None)?;
+    }
+    // Normals: nz -> -nz, NaN -> 0
+    for vw in block.vertices {
+        let nx = if vw.vertex.nx.is_nan() {
+            0.0
+        } else {
+            vw.vertex.nx
+        };
+        let ny = if vw.vertex.ny.is_nan() {
+            0.0
+        } else {
+            vw.vertex.ny
+        };
+        let nz = if vw.vertex.nz.is_nan() {
+            0.0
+        } else {
+            -vw.vertex.nz
+        };
+        obj.write_normal(nx, ny, nz)?;
+    }
+
+    let material_obj_name = if let Some(material_name) = block.material_name {
+        let mtl_name = ensure_mtl_block(mtl, state, fs, material_name, block.texture_name)?;
+        obj.write_use_material(&mtl_name)?;
+        Some(mtl_name)
+    } else {
+        None
+    };
+    let _ = material_obj_name;
+
+    if block.smoothing {
+        obj.write_smoothing_group(SmoothingGroup::Group(1))?;
+    }
+
+    // Faces: 1-based, +face_offset, reversed winding.
+    for face in block.indices {
+        let v1 = (face.i2 as u32 + 1 + state.face_offset) as usize;
+        let v2 = (face.i1 as u32 + 1 + state.face_offset) as usize;
+        let v3 = (face.i0 as u32 + 1 + state.face_offset) as usize;
+        obj.write_face(&[
+            (v1, Some(v1), Some(v1)),
+            (v2, Some(v2), Some(v2)),
+            (v3, Some(v3), Some(v3)),
+        ])?;
+    }
+
+    state.face_offset = state
+        .face_offset
+        .saturating_add(block.vertices.len() as u32);
+    Ok(())
+}
+
+/// Emit a `newmtl` block for `(material_name, texture_name)` if not seen
+/// before, and side-effect: write the referenced image to disk on first use.
+/// Returns the material name as written (with spaces erased - VPinball does
+/// the same in `WriteMaterial` for both the MTL block and the `usemtl`).
+fn ensure_mtl_block<M: MtlWriter<f32>>(
+    mtl: &mut M,
+    state: &mut WriterState,
+    fs: &dyn FileSystem,
+    material_name: &str,
+    texture_name: Option<&str>,
+) -> io::Result<String> {
+    let texture_key = texture_name.unwrap_or("").to_string();
+    let key = (material_name.to_string(), texture_key);
+    let mtl_name = sanitize_material_name(material_name);
+
+    if state.seen_mtl_pairs.contains(&key) {
+        // Still ensure the image file exists if texture is set (e.g. same
+        // material reused with same texture - already covered).
+        return Ok(mtl_name);
+    }
+    state.seen_mtl_pairs.insert(key);
+
+    // Resolve the on-disk image filename and ensure the file is written.
+    let map_path = if let Some(name) = texture_name {
+        ensure_image_written(state, fs, name)?
+    } else {
+        None
+    };
+
+    write_mtl_block(mtl, state, &mtl_name, material_name, map_path.as_deref())?;
+    Ok(mtl_name)
+}
+
+/// Match VPinball's `WriteMaterial` (`std::erase(' ')`).
+fn sanitize_material_name(name: &str) -> String {
+    name.chars().filter(|c| *c != ' ').collect()
+}
+
+fn write_mtl_block<M: MtlWriter<f32>>(
+    mtl: &mut M,
+    state: &WriterState,
+    mtl_name: &str,
+    material_name: &str,
+    image_relative_path: Option<&str>,
+) -> io::Result<()> {
+    let material = state.material_by_name(material_name);
+
+    // Defaults match VPinball's WriteMaterial when no Material is found.
+    let (kd, ks, opacity) = match material {
+        Some(m) => (
+            color_to_kd(m),
+            color_to_ks(m),
+            if m.opacity_active { m.opacity } else { 1.0 },
+        ),
+        None => ([1.0, 1.0, 1.0], [0.0, 0.0, 0.0], 1.0),
+    };
+
+    mtl.write_new_material(mtl_name)?;
+    mtl.write_specular_exponent(7.843137)?;
+    mtl.write_ambient(0.0, Some(0.0), Some(0.0))?;
+    mtl.write_diffuse(kd[0], Some(kd[1]), Some(kd[2]))?;
+    mtl.write_specular(ks[0], Some(ks[1]), Some(ks[2]))?;
+    mtl.write_optical_density(1.5)?;
+    mtl.write_dissolve(opacity)?;
+    mtl.write_illumination_model(5)?;
+    if let Some(path) = image_relative_path {
+        mtl.write_map(MapKind::Diffuse, path)?;
+        mtl.write_map(MapKind::Ambient, path)?;
+    }
+    Ok(())
+}
+
+fn color_to_kd(m: &Material) -> [f32; 3] {
+    [
+        m.base_color.r as f32 / 255.0,
+        m.base_color.g as f32 / 255.0,
+        m.base_color.b as f32 / 255.0,
+    ]
+}
+
+fn color_to_ks(m: &Material) -> [f32; 3] {
+    if m.type_ == MaterialType::Metal {
+        // Match VPinball's `m_cGlossy` for metals (uses base color).
+        color_to_kd(m)
+    } else {
+        [
+            m.glossy_color.r as f32 / 255.0,
+            m.glossy_color.g as f32 / 255.0,
+            m.glossy_color.b as f32 / 255.0,
+        ]
+    }
+}
+
+/// Look up the image by `name`, write it to `images/` if not already
+/// written, and return the relative path for the `.mtl` (or None if the
+/// image is missing or has no data).
+fn ensure_image_written(
+    state: &mut WriterState,
+    fs: &dyn FileSystem,
+    name: &str,
+) -> io::Result<Option<String>> {
+    if state.images_written.contains(name) {
+        return Ok(state
+            .image_filenames
+            .get(name)
+            .map(|f| format!("images/{}", f)));
+    }
+    // Clone the bits we need from the image before we mutably borrow state.
+    let (image_name, image_ext, payload) = {
+        let Some(image) = state.image_by_name(name) else {
+            warn!("Texture '{name}' referenced but not found in vpx.images");
+            return Ok(None);
+        };
+        let payload = if let Some(jpeg) = &image.jpeg {
+            ImagePayload::Raw(jpeg.data.clone())
+        } else if let Some(bits) = &image.bits {
+            ImagePayload::Bmp {
+                lzw: bits.lzw_compressed_data.clone(),
+                width: image.width,
+                height: image.height,
+            }
+        } else {
+            warn!("Texture '{name}' has no data; skipping");
+            return Ok(None);
+        };
+        (image.name.clone(), image.ext(), payload)
+    };
+
+    let on_disk = sanitized_image_filename(state, &image_name, &image_ext);
+    let path = state.images_dir.join(&on_disk);
+    fs.create_dir_all(&state.images_dir)?;
+
+    match payload {
+        ImagePayload::Raw(bytes) => fs.write_file(&path, &bytes)?,
+        ImagePayload::Bmp { lzw, width, height } => {
+            write_image_bmp(&path, &lzw, width, height, fs)?
+        }
+    }
+
+    state.images_written.insert(name.to_string());
+    state
+        .image_filenames
+        .insert(name.to_string(), on_disk.clone());
+    Ok(Some(format!("images/{}", on_disk)))
+}
+
+enum ImagePayload {
+    Raw(Vec<u8>),
+    Bmp {
+        lzw: Vec<u8>,
+        width: u32,
+        height: u32,
+    },
+}
+
+fn sanitized_image_filename(state: &mut WriterState, name: &str, ext: &str) -> String {
+    let base = sanitize_filename(name);
+    let mut filename = format!("{}.{}", base, ext);
+    let mut lower = filename.to_lowercase();
+    while state.used_lower_filenames.contains(&lower) {
+        state.image_dedup_counter += 1;
+        filename = format!("{}_dedup{}.{}", base, state.image_dedup_counter, ext);
+        lower = filename.to_lowercase();
+    }
+    state.used_lower_filenames.insert(lower);
+    filename
+}
+
+fn write_image_bmp(
+    path: &Path,
+    lzw_compressed: &[u8],
+    width: u32,
+    height: u32,
+    fs: &dyn FileSystem,
+) -> io::Result<()> {
+    use crate::vpx::image::vpx_image_to_dynamic_image;
+    use std::io::Cursor;
+    let dynamic = vpx_image_to_dynamic_image(lzw_compressed, width, height);
+    let mut buffer = Cursor::new(Vec::new());
+    dynamic
+        .write_to(&mut buffer, image::ImageFormat::Bmp)
+        .map_err(|e| io::Error::other(format!("Failed to encode BMP {}: {e}", path.display())))?;
+    fs.write_file(path, buffer.get_ref())
+}

--- a/src/vpx/export/obj_export.rs
+++ b/src/vpx/export/obj_export.rs
@@ -141,9 +141,6 @@ struct WriterState<'a> {
     /// `m_faceIndexOffset` and bumps it after each item by the number of
     /// vertices written.
     face_offset: u32,
-    /// `(material_name, texture_name)` pairs that already have a `newmtl`
-    /// block emitted. Texture name is empty when the material has no image.
-    seen_mtl_pairs: HashSet<(String, String)>,
     /// Mapping from VPX image name (case-preserving) to the on-disk file
     /// name inside `images/`. Populated lazily as textures are referenced.
     image_filenames: HashMap<String, String>,
@@ -169,7 +166,6 @@ impl<'a> WriterState<'a> {
             ),
             detail_level: vpx.gamedata.effective_detail_level(),
             face_offset: 0,
-            seen_mtl_pairs: HashSet::new(),
             image_filenames: HashMap::new(),
             used_lower_filenames: HashSet::new(),
             image_dedup_counter: 0,
@@ -233,11 +229,11 @@ fn write_playfield<O: ObjWriter<f32>, M: MtlWriter<f32>>(
         state.vpx.gamedata.bottom,
     );
 
-    let material_name = if state.vpx.gamedata.playfield_material.is_empty() {
-        None
-    } else {
-        Some(state.vpx.gamedata.playfield_material.clone())
-    };
+    // VPinball's `PinTable::ExportMesh` always emits `WriteMaterial(m_szPlayfieldMaterial, ...)`
+    // and `UseTexture(m_szPlayfieldMaterial)` - so we always emit a `usemtl`
+    // and a corresponding `newmtl` block, even if the playfield material
+    // name is empty.
+    let material_name = state.vpx.gamedata.playfield_material.clone();
     let texture_name = if state.vpx.gamedata.image.is_empty() {
         None
     } else {
@@ -257,7 +253,7 @@ fn write_playfield<O: ObjWriter<f32>, M: MtlWriter<f32>>(
             vertices: &vertices,
             indices: &indices,
             translation: Vec3::new(0.0, 0.0, 0.0),
-            material_name: material_name.as_deref(),
+            material_name: Some(&material_name),
             texture_name: texture_name.as_deref(),
             smoothing: true,
         },
@@ -347,29 +343,19 @@ fn write_primitive<O: ObjWriter<f32>, M: MtlWriter<f32>>(
     // Playfield primitives in VPinball pull material/image from gamedata,
     // not from the primitive's own fields.
     let (material_name, texture_name) = if primitive.is_playfield() {
-        let m = if state.vpx.gamedata.playfield_material.is_empty() {
-            None
-        } else {
-            Some(state.vpx.gamedata.playfield_material.clone())
-        };
         let t = if state.vpx.gamedata.image.is_empty() {
             None
         } else {
             Some(state.vpx.gamedata.image.clone())
         };
-        (m, t)
+        (state.vpx.gamedata.playfield_material.clone(), t)
     } else {
-        let m = if primitive.material.is_empty() {
-            None
-        } else {
-            Some(primitive.material.clone())
-        };
         let t = if primitive.image.is_empty() {
             None
         } else {
             Some(primitive.image.clone())
         };
-        (m, t)
+        (primitive.material.clone(), t)
     };
 
     write_block(
@@ -382,7 +368,7 @@ fn write_primitive<O: ObjWriter<f32>, M: MtlWriter<f32>>(
             vertices: &vertices,
             indices: &read.indices,
             translation: Vec3::new(0.0, 0.0, 0.0),
-            material_name: material_name.as_deref(),
+            material_name: Some(&material_name),
             texture_name: texture_name.as_deref(),
             smoothing: false,
         },
@@ -434,15 +420,14 @@ fn write_wall<O: ObjWriter<f32>, M: MtlWriter<f32>>(
         meshes.side,
     ) {
         (true, false, Some((vertices, indices)), _) => {
-            let material_name = if !wall.top_material.is_empty() {
-                Some(wall.top_material.clone())
+            // VPinball top-only special case (surface.cpp:690-707):
+            // when an image is set, the OBJ material name is the image
+            // name (not the top material) and the MTL receives the
+            // texture file path. When no image, material name is "none".
+            let (material_name, texture_name) = if wall.image.is_empty() {
+                ("none".to_string(), None)
             } else {
-                None
-            };
-            let texture_name = if !wall.image.is_empty() {
-                Some(wall.image.clone())
-            } else {
-                None
+                (wall.image.clone(), Some(wall.image.clone()))
             };
             write_block(
                 obj,
@@ -454,23 +439,14 @@ fn write_wall<O: ObjWriter<f32>, M: MtlWriter<f32>>(
                     vertices: &vertices,
                     indices: &indices,
                     translation: Vec3::new(0.0, 0.0, 0.0),
-                    material_name: material_name.as_deref(),
+                    material_name: Some(&material_name),
                     texture_name: texture_name.as_deref(),
                     smoothing: false,
                 },
             )?;
         }
         (false, true, _, Some((vertices, indices))) => {
-            let material_name = if !wall.side_material.is_empty() {
-                Some(wall.side_material.clone())
-            } else {
-                None
-            };
-            let texture_name = if !wall.side_image.is_empty() {
-                Some(wall.side_image.clone())
-            } else {
-                None
-            };
+            let material_name = wall.side_material.clone();
             write_block(
                 obj,
                 mtl,
@@ -481,8 +457,8 @@ fn write_wall<O: ObjWriter<f32>, M: MtlWriter<f32>>(
                     vertices: &vertices,
                     indices: &indices,
                     translation: Vec3::new(0.0, 0.0, 0.0),
-                    material_name: material_name.as_deref(),
-                    texture_name: texture_name.as_deref(),
+                    material_name: Some(&material_name),
+                    texture_name: None,
                     smoothing: false,
                 },
             )?;
@@ -497,11 +473,7 @@ fn write_wall<O: ObjWriter<f32>, M: MtlWriter<f32>>(
                 i1: f.i1 + side_count,
                 i2: f.i2 + side_count,
             }));
-            let material_name = if !wall.top_material.is_empty() {
-                Some(wall.top_material.clone())
-            } else {
-                None
-            };
+            let material_name = wall.top_material.clone();
             write_block(
                 obj,
                 mtl,
@@ -512,7 +484,7 @@ fn write_wall<O: ObjWriter<f32>, M: MtlWriter<f32>>(
                     vertices: &combined_v,
                     indices: &combined_i,
                     translation: Vec3::new(0.0, 0.0, 0.0),
-                    material_name: material_name.as_deref(),
+                    material_name: Some(&material_name),
                     texture_name: None,
                     smoothing: true,
                 },
@@ -548,11 +520,7 @@ fn write_ramp<O: ObjWriter<f32>, M: MtlWriter<f32>>(
     ) else {
         return Ok(());
     };
-    let material_name = if ramp.material.is_empty() {
-        None
-    } else {
-        Some(ramp.material.clone())
-    };
+    let material_name = ramp.material.clone();
     let texture_name = if ramp.image.is_empty() {
         None
     } else {
@@ -568,7 +536,7 @@ fn write_ramp<O: ObjWriter<f32>, M: MtlWriter<f32>>(
             vertices: &vertices,
             indices: &indices,
             translation: Vec3::new(0.0, 0.0, 0.0),
-            material_name: material_name.as_deref(),
+            material_name: Some(&material_name),
             texture_name: texture_name.as_deref(),
             smoothing: true,
         },
@@ -588,11 +556,7 @@ fn write_rubber<O: ObjWriter<f32>, M: MtlWriter<f32>>(
     let Some((vertices, indices, center)) = build_rubber_mesh(rubber, state.detail_level) else {
         return Ok(());
     };
-    let material_name = if rubber.material.is_empty() {
-        None
-    } else {
-        Some(rubber.material.clone())
-    };
+    let material_name = rubber.material.clone();
     write_block(
         obj,
         mtl,
@@ -603,7 +567,7 @@ fn write_rubber<O: ObjWriter<f32>, M: MtlWriter<f32>>(
             vertices: &vertices,
             indices: &indices,
             translation: center,
-            material_name: material_name.as_deref(),
+            material_name: Some(&material_name),
             texture_name: None,
             smoothing: true,
         },
@@ -622,11 +586,7 @@ fn write_bumper<O: ObjWriter<f32>, M: MtlWriter<f32>>(
     let meshes = build_bumper_meshes(bumper);
 
     if let Some((vertices, indices)) = meshes.base {
-        let material_name = if bumper.base_material.is_empty() {
-            None
-        } else {
-            Some(bumper.base_material.clone())
-        };
+        let material_name = bumper.base_material.clone();
         write_block(
             obj,
             mtl,
@@ -637,7 +597,7 @@ fn write_bumper<O: ObjWriter<f32>, M: MtlWriter<f32>>(
                 vertices: &vertices,
                 indices: &indices,
                 translation,
-                material_name: material_name.as_deref(),
+                material_name: Some(&material_name),
                 texture_name: None,
                 smoothing: true,
             },
@@ -664,11 +624,7 @@ fn write_bumper<O: ObjWriter<f32>, M: MtlWriter<f32>>(
         )?;
     }
     if let Some((vertices, indices)) = meshes.socket {
-        let material_name = if bumper.socket_material.is_empty() {
-            None
-        } else {
-            Some(bumper.socket_material.clone())
-        };
+        let material_name = bumper.socket_material.clone();
         write_block(
             obj,
             mtl,
@@ -679,18 +635,14 @@ fn write_bumper<O: ObjWriter<f32>, M: MtlWriter<f32>>(
                 vertices: &vertices,
                 indices: &indices,
                 translation,
-                material_name: material_name.as_deref(),
+                material_name: Some(&material_name),
                 texture_name: None,
                 smoothing: true,
             },
         )?;
     }
     if let Some((vertices, indices)) = meshes.cap {
-        let material_name = if bumper.cap_material.is_empty() {
-            None
-        } else {
-            Some(bumper.cap_material.clone())
-        };
+        let material_name = bumper.cap_material.clone();
         write_block(
             obj,
             mtl,
@@ -701,7 +653,7 @@ fn write_bumper<O: ObjWriter<f32>, M: MtlWriter<f32>>(
                 vertices: &vertices,
                 indices: &indices,
                 translation,
-                material_name: material_name.as_deref(),
+                material_name: Some(&material_name),
                 texture_name: None,
                 smoothing: true,
             },
@@ -724,11 +676,7 @@ fn write_flipper<O: ObjWriter<f32>, M: MtlWriter<f32>>(
     let translation = meshes.center;
 
     let (base_vertices, base_indices) = meshes.base;
-    let base_material = if flipper.material.is_empty() {
-        None
-    } else {
-        Some(flipper.material.clone())
-    };
+    let base_material = flipper.material.clone();
     let base_texture = flipper.image.as_ref().filter(|s| !s.is_empty()).cloned();
     write_block(
         obj,
@@ -740,18 +688,14 @@ fn write_flipper<O: ObjWriter<f32>, M: MtlWriter<f32>>(
             vertices: &base_vertices,
             indices: &base_indices,
             translation,
-            material_name: base_material.as_deref(),
+            material_name: Some(&base_material),
             texture_name: base_texture.as_deref(),
             smoothing: true,
         },
     )?;
 
     if let Some((rubber_vertices, rubber_indices)) = meshes.rubber {
-        let rubber_material = if flipper.rubber_material.is_empty() {
-            None
-        } else {
-            Some(flipper.rubber_material.clone())
-        };
+        let rubber_material = flipper.rubber_material.clone();
         write_block(
             obj,
             mtl,
@@ -762,7 +706,7 @@ fn write_flipper<O: ObjWriter<f32>, M: MtlWriter<f32>>(
                 vertices: &rubber_vertices,
                 indices: &rubber_indices,
                 translation,
-                material_name: rubber_material.as_deref(),
+                material_name: Some(&rubber_material),
                 texture_name: None,
                 smoothing: true,
             },
@@ -784,11 +728,7 @@ fn write_gate<O: ObjWriter<f32>, M: MtlWriter<f32>>(
     let Some(meshes) = build_gate_meshes_unchecked(gate) else {
         return Ok(());
     };
-    let material_name = if gate.material.is_empty() {
-        None
-    } else {
-        Some(gate.material.clone())
-    };
+    let material_name = gate.material.clone();
     if let Some((vertices, indices)) = meshes.bracket {
         write_block(
             obj,
@@ -800,7 +740,7 @@ fn write_gate<O: ObjWriter<f32>, M: MtlWriter<f32>>(
                 vertices: &vertices,
                 indices: &indices,
                 translation,
-                material_name: material_name.as_deref(),
+                material_name: Some(&material_name),
                 texture_name: None,
                 smoothing: true,
             },
@@ -817,7 +757,7 @@ fn write_gate<O: ObjWriter<f32>, M: MtlWriter<f32>>(
             vertices: &vertices,
             indices: &indices,
             translation,
-            material_name: material_name.as_deref(),
+            material_name: Some(&material_name),
             texture_name: None,
             smoothing: true,
         },
@@ -840,11 +780,7 @@ fn write_kicker<O: ObjWriter<f32>, M: MtlWriter<f32>>(
     let surface_height = state.surface_height(&kicker.surface, kicker.center.x, kicker.center.y);
     let translation = Vec3::new(kicker.center.x, kicker.center.y, surface_height);
     let meshes = build_kicker_meshes(kicker);
-    let material_name = if kicker.material.is_empty() {
-        None
-    } else {
-        Some(kicker.material.clone())
-    };
+    let material_name = kicker.material.clone();
     if let Some((vertices, indices)) = meshes.plate {
         write_block(
             obj,
@@ -856,7 +792,7 @@ fn write_kicker<O: ObjWriter<f32>, M: MtlWriter<f32>>(
                 vertices: &vertices,
                 indices: &indices,
                 translation,
-                material_name: material_name.as_deref(),
+                material_name: Some(&material_name),
                 texture_name: None,
                 smoothing: true,
             },
@@ -873,7 +809,7 @@ fn write_kicker<O: ObjWriter<f32>, M: MtlWriter<f32>>(
                 vertices: &vertices,
                 indices: &indices,
                 translation,
-                material_name: material_name.as_deref(),
+                material_name: Some(&material_name),
                 texture_name: None,
                 smoothing: true,
             },
@@ -897,7 +833,11 @@ fn write_spinner<O: ObjWriter<f32>, M: MtlWriter<f32>>(
         surface_height + spinner.height,
     );
     let meshes = build_spinner_meshes(spinner);
+    let material_name = spinner.material.clone();
     if let Some((vertices, indices)) = meshes.bracket {
+        // VPinball's `Spinner::ExportMesh` (spinner.cpp:273) emits
+        // `WriteMaterial(m_szMaterial)` and `UseTexture(m_szMaterial)`
+        // for the bracket.
         write_block(
             obj,
             mtl,
@@ -908,23 +848,13 @@ fn write_spinner<O: ObjWriter<f32>, M: MtlWriter<f32>>(
                 vertices: &vertices,
                 indices: &indices,
                 translation,
-                material_name: None,
+                material_name: Some(&material_name),
                 texture_name: None,
                 smoothing: true,
             },
         )?;
     }
     let (vertices, indices) = meshes.plate;
-    let material_name = if spinner.material.is_empty() {
-        None
-    } else {
-        Some(spinner.material.clone())
-    };
-    let texture_name = if spinner.image.is_empty() {
-        None
-    } else {
-        Some(spinner.image.clone())
-    };
     write_block(
         obj,
         mtl,
@@ -935,8 +865,11 @@ fn write_spinner<O: ObjWriter<f32>, M: MtlWriter<f32>>(
             vertices: &vertices,
             indices: &indices,
             translation,
-            material_name: material_name.as_deref(),
-            texture_name: texture_name.as_deref(),
+            // VPinball does NOT emit `WriteMaterial`/`UseTexture` for the
+            // spinner plate (spinner.cpp:286-291). The plate inherits the
+            // bracket's material in the OBJ.
+            material_name: None,
+            texture_name: None,
             smoothing: true,
         },
     )
@@ -954,11 +887,7 @@ fn write_hittarget<O: ObjWriter<f32>, M: MtlWriter<f32>>(
         return Ok(());
     };
     let translation = Vec3::new(target.position.x, target.position.y, target.position.z);
-    let material_name = if target.material.is_empty() {
-        None
-    } else {
-        Some(target.material.clone())
-    };
+    let material_name = target.material.clone();
     let texture_name = if target.image.is_empty() {
         None
     } else {
@@ -974,7 +903,7 @@ fn write_hittarget<O: ObjWriter<f32>, M: MtlWriter<f32>>(
             vertices: &vertices,
             indices: &indices,
             translation,
-            material_name: material_name.as_deref(),
+            material_name: Some(&material_name),
             texture_name: texture_name.as_deref(),
             smoothing: true,
         },
@@ -996,11 +925,7 @@ fn write_trigger<O: ObjWriter<f32>, M: MtlWriter<f32>>(
     let Some((vertices, indices)) = build_trigger_mesh(trigger) else {
         return Ok(());
     };
-    let material_name = if trigger.material.is_empty() {
-        None
-    } else {
-        Some(trigger.material.clone())
-    };
+    let material_name = trigger.material.clone();
     write_block(
         obj,
         mtl,
@@ -1011,7 +936,7 @@ fn write_trigger<O: ObjWriter<f32>, M: MtlWriter<f32>>(
             vertices: &vertices,
             indices: &indices,
             translation,
-            material_name: material_name.as_deref(),
+            material_name: Some(&material_name),
             texture_name: None,
             smoothing: true,
         },
@@ -1087,14 +1012,14 @@ fn write_block<O: ObjWriter<f32>, M: MtlWriter<f32>>(
         obj.write_normal(nx, ny, nz)?;
     }
 
-    let material_obj_name = if let Some(material_name) = block.material_name {
-        let mtl_name = ensure_mtl_block(mtl, state, fs, material_name, block.texture_name)?;
+    // VPinball calls `WriteMaterial` + `UseTexture` for every item in
+    // `ExportMesh`, even when the material name is empty - so the MTL ends
+    // up with one `newmtl` block per `usemtl`, with duplicates. We emit
+    // exactly the same way (no dedup) for parity.
+    if let Some(material_name) = block.material_name {
+        let mtl_name = emit_mtl_block(mtl, state, fs, material_name, block.texture_name)?;
         obj.write_use_material(&mtl_name)?;
-        Some(mtl_name)
-    } else {
-        None
-    };
-    let _ = material_obj_name;
+    }
 
     if block.smoothing {
         obj.write_smoothing_group(SmoothingGroup::Group(1))?;
@@ -1118,27 +1043,18 @@ fn write_block<O: ObjWriter<f32>, M: MtlWriter<f32>>(
     Ok(())
 }
 
-/// Emit a `newmtl` block for `(material_name, texture_name)` if not seen
-/// before, and side-effect: write the referenced image to disk on first use.
-/// Returns the material name as written (with spaces erased - VPinball does
-/// the same in `WriteMaterial` for both the MTL block and the `usemtl`).
-fn ensure_mtl_block<M: MtlWriter<f32>>(
+/// Emit one `newmtl` block (no dedup, matches VPinball) and write the
+/// referenced image to disk on first use. Returns the material name as
+/// written (with spaces erased - VPinball does the same in `WriteMaterial`
+/// for both the MTL block and the `usemtl`).
+fn emit_mtl_block<M: MtlWriter<f32>>(
     mtl: &mut M,
     state: &mut WriterState,
     fs: &dyn FileSystem,
     material_name: &str,
     texture_name: Option<&str>,
 ) -> io::Result<String> {
-    let texture_key = texture_name.unwrap_or("").to_string();
-    let key = (material_name.to_string(), texture_key);
     let mtl_name = sanitize_material_name(material_name);
-
-    if state.seen_mtl_pairs.contains(&key) {
-        // Still ensure the image file exists if texture is set (e.g. same
-        // material reused with same texture - already covered).
-        return Ok(mtl_name);
-    }
-    state.seen_mtl_pairs.insert(key);
 
     // Resolve the on-disk image filename and ensure the file is written.
     let map_path = if let Some(name) = texture_name {

--- a/src/vpx/mesh/flippers/mod.rs
+++ b/src/vpx/mesh/flippers/mod.rs
@@ -494,7 +494,18 @@ pub fn build_flipper_meshes(flipper: &Flipper, surface_height: f32) -> Option<Fl
     if !flipper.is_visible {
         return None;
     }
+    build_flipper_meshes_unchecked(flipper, surface_height)
+}
 
+/// Like [`build_flipper_meshes`] but skips the runtime visibility check.
+///
+/// VPinball's `Flipper::ExportMesh` does not consult `m_d.m_visible` -
+/// it only filters at the table level via `m_uiVisible`. The OBJ exporter
+/// uses this variant to match.
+pub(crate) fn build_flipper_meshes_unchecked(
+    flipper: &Flipper,
+    surface_height: f32,
+) -> Option<FlipperMeshes> {
     let rubber_thickness = flipper
         .rubber_thickness
         .unwrap_or(flipper.rubber_thickness_int as f32);

--- a/src/vpx/mesh/gates/mod.rs
+++ b/src/vpx/mesh/gates/mod.rs
@@ -180,7 +180,15 @@ pub fn build_gate_meshes(gate: &Gate) -> Option<GateMeshes> {
     if !gate.is_visible {
         return None;
     }
+    build_gate_meshes_unchecked(gate)
+}
 
+/// Like [`build_gate_meshes`] but skips the runtime visibility check.
+///
+/// VPinball's `Gate::ExportMesh` does not consult `m_d.m_visible` (the
+/// runtime visibility flag) - it only filters at the table level via
+/// `m_uiVisible`. The OBJ exporter uses this variant to match.
+pub(crate) fn build_gate_meshes_unchecked(gate: &Gate) -> Option<GateMeshes> {
     // Get the appropriate mesh for this gate type (default to WireW if not specified)
     let gate_type = gate.gate_type.as_ref().unwrap_or(&GateType::WireW);
     let (mesh, indices) = get_mesh_for_type(gate_type);

--- a/src/vpx/mesh/hittargets/mod.rs
+++ b/src/vpx/mesh/hittargets/mod.rs
@@ -87,7 +87,17 @@ pub fn build_hit_target_mesh(target: &HitTarget) -> Option<(Vec<VertexWrapper>, 
     if !target.is_visible {
         return None;
     }
+    build_hit_target_mesh_unchecked(target)
+}
 
+/// Like [`build_hit_target_mesh`] but skips the runtime visibility check.
+///
+/// VPinball's `HitTarget::ExportMesh` does not consult `m_d.m_visible` -
+/// it only filters at the table level via `m_uiVisible`. The OBJ exporter
+/// uses this variant to match.
+pub(crate) fn build_hit_target_mesh_unchecked(
+    target: &HitTarget,
+) -> Option<(Vec<VertexWrapper>, Vec<VpxFace>)> {
     let (mesh, indices) = get_mesh_for_type(&target.target_type);
     let full_matrix = Mat3::rotate_z(target.rot_z.to_radians());
 


### PR DESCRIPTION
Implements full-table Wavefront OBJ export, mirroring vpinball's
`File -> Export -> OBJ Mesh`. Output is a single `.obj` + `.mtl` pair
plus a sibling `images/` folder with the textures referenced from the
MTL.

```rust
use vpin::vpx::export::obj_export::{export_obj, ObjExportOptions};

export_obj(&vpx, Path::new("table.obj"), &fs, &ObjExportOptions::default())?;
```

`ObjExportOptions::default()` matches vpinball byte-for-byte (modulo
float formatting). The single knob today is `dedup_mtl_blocks` (off
by default) which collapses the MTL when the same material is reused
across many items.