### PR TITLE
fix(vpx): vpinball mesh-generation parity for ramps, rubbers and walls

### DIFF
--- a/src/vpx/expanded/primitives.rs
+++ b/src/vpx/expanded/primitives.rs
@@ -513,7 +513,12 @@ fn write_ramp_meshes(
     table_dims: &TableDimensions,
     fs: &dyn FileSystem,
 ) -> Result<(), WriteError> {
-    let Some((vertices, indices)) = build_ramp_mesh(ramp, table_dims) else {
+    // The expanded format is a portable representation - it doesn't have
+    // access to the table's `user_detail_level` here, so we use the
+    // editor default. This matches how default `table_dims` is used above.
+    let Some((vertices, indices)) =
+        build_ramp_mesh(ramp, table_dims, crate::vpx::gamedata::DEFAULT_DETAIL_LEVEL)
+    else {
         return Ok(());
     };
 
@@ -528,7 +533,9 @@ fn write_rubber_meshes(
     mesh_format: PrimitiveMeshFormat,
     fs: &dyn FileSystem,
 ) -> Result<(), WriteError> {
-    let Some((vertices, indices, _center)) = build_rubber_mesh(rubber) else {
+    let Some((vertices, indices, _center)) =
+        build_rubber_mesh(rubber, crate::vpx::gamedata::DEFAULT_DETAIL_LEVEL)
+    else {
         return Ok(());
     };
 

--- a/src/vpx/expanded/primitives.rs
+++ b/src/vpx/expanded/primitives.rs
@@ -513,12 +513,17 @@ fn write_ramp_meshes(
     table_dims: &TableDimensions,
     fs: &dyn FileSystem,
 ) -> Result<(), WriteError> {
-    // The expanded format is a portable representation - it doesn't have
-    // access to the table's `user_detail_level` here, so we use the
-    // editor default. This matches how default `table_dims` is used above.
-    let Some((vertices, indices)) =
-        build_ramp_mesh(ramp, table_dims, crate::vpx::gamedata::DEFAULT_DETAIL_LEVEL)
-    else {
+    // The expanded format is a portable representation - it doesn't
+    // have access to the table's `user_detail_level` or the ramp's
+    // material here, so we use the editor default for detail level
+    // and assume the material is opaque (vpinball's dummy-material
+    // default; the typical case for ramps).
+    let Some((vertices, indices)) = build_ramp_mesh(
+        ramp,
+        table_dims,
+        crate::vpx::gamedata::DEFAULT_DETAIL_LEVEL,
+        false, // material_opacity_active
+    ) else {
         return Ok(());
     };
 

--- a/src/vpx/export/gltf_export.rs
+++ b/src/vpx/export/gltf_export.rs
@@ -759,6 +759,7 @@ fn collect_meshes(vpx: &VPX, options: &GltfExportOptions) -> (Vec<NamedMesh>, Ve
         vpx.gamedata.right,
         vpx.gamedata.bottom,
     );
+    let detail_level = vpx.gamedata.effective_detail_level();
 
     for gameitem in &vpx.gameitems {
         match gameitem {
@@ -912,7 +913,8 @@ fn collect_meshes(vpx: &VPX, options: &GltfExportOptions) -> (Vec<NamedMesh>, Ve
                 if !options.export_invisible_items && !ramp.is_visible {
                     continue;
                 }
-                if let Some((vertices, indices)) = build_ramp_mesh(ramp, &table_dims) {
+                if let Some((vertices, indices)) = build_ramp_mesh(ramp, &table_dims, detail_level)
+                {
                     let group_info = item_group_info_for(ramp);
                     let ramp_layer_name = group_info.layer_name.clone();
                     item_groups.push(group_info);
@@ -945,7 +947,7 @@ fn collect_meshes(vpx: &VPX, options: &GltfExportOptions) -> (Vec<NamedMesh>, Ve
                 if !options.export_invisible_items && !rubber.is_visible {
                     continue;
                 }
-                if let Some((vertices, indices, center)) = build_rubber_mesh(rubber) {
+                if let Some((vertices, indices, center)) = build_rubber_mesh(rubber, detail_level) {
                     let group_info = item_group_info_for(rubber);
                     let rubber_layer_name = group_info.layer_name.clone();
                     item_groups.push(group_info);

--- a/src/vpx/export/gltf_export.rs
+++ b/src/vpx/export/gltf_export.rs
@@ -913,7 +913,22 @@ fn collect_meshes(vpx: &VPX, options: &GltfExportOptions) -> (Vec<NamedMesh>, Ve
                 if !options.export_invisible_items && !ramp.is_visible {
                     continue;
                 }
-                if let Some((vertices, indices)) = build_ramp_mesh(ramp, &table_dims, detail_level)
+                // VPinball's `Ramp::GenerateWireMesh` uses max-precision
+                // wire segments when the material is opaque
+                // (`!mat->m_bOpacityActive`). Look the material up;
+                // missing/empty falls through to opaque (vpinball's
+                // dummy material defaults `m_bOpacityActive = false`).
+                let material_opacity_active = vpx
+                    .gamedata
+                    .materials
+                    .as_ref()
+                    .and_then(|mats| {
+                        mats.iter()
+                            .find(|m| m.name.eq_ignore_ascii_case(&ramp.material))
+                    })
+                    .is_some_and(|m| m.opacity_active);
+                if let Some((vertices, indices)) =
+                    build_ramp_mesh(ramp, &table_dims, detail_level, material_opacity_active)
                 {
                     let group_info = item_group_info_for(ramp);
                     let ramp_layer_name = group_info.layer_name.clone();

--- a/src/vpx/gamedata.rs
+++ b/src/vpx/gamedata.rs
@@ -47,8 +47,10 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 /// VPinball's editor default for per-table detail level. Used as a fallback
 /// when [`GameData::user_detail_level`] is `None`.
 ///
-/// VPinball's editor defaults this to 10 (highest detail). The value drives
-/// ramp and rubber tessellation - see
+/// VPinball declares the corresponding `Player_AlphaRampAccuracy` property
+/// as `(min = 1, max = 10, default = 10)` in `Settings_properties.inl`, so
+/// 10 is also the highest-detail setting the editor's slider exposes. The
+/// value drives ramp and rubber tessellation - see
 /// [`crate::vpx::mesh::vpinball_ring_segments`].
 pub const DEFAULT_DETAIL_LEVEL: u32 = 10;
 
@@ -867,13 +869,22 @@ pub struct GameData {
     /// this has a special quantization,
     /// See [`Self::get_ball_trail_strength`] and [`Self::set_ball_trail_strength`]
     pub ball_trail_strength: Option<u32>, // BTST 93 (became optional in 10.8)
-    /// Per-table detail level override (range `0..=10`, where 10 is the
-    /// highest detail).
+    /// Per-table detail level override (range `1..=10`, where 10 is the
+    /// highest detail). VPinball declares the underlying property as
+    /// `(min = 1, max = 10, default = 10)` in `Settings_properties.inl`.
     ///
     /// VPinball's editor exposes this as the "detail level" slider. It
     /// drives ramp and rubber tessellation; see
     /// [`crate::vpx::mesh::vpinball_ring_segments`] for how vpinball
     /// derives the cross-section segment count from this value.
+    ///
+    /// Note: older vpinball versions allowed `0` and the user-level ini
+    /// (`%APPDATA%\VPinballX\<ver>\VPinballX.ini`, key
+    /// `[Player] AlphaRampAccuracy`) can still carry a `0` from those
+    /// versions. The store does not clamp to `m_min`, so any integer
+    /// can appear in practice. Callers should treat values outside the
+    /// declared range as legacy data and route them through the formula
+    /// regardless (the formula's `accuracy < 5` branch handles them).
     ///
     /// Only takes effect when [`Self::overwrite_global_detail_level`] is
     /// `Some(true)`. Otherwise vpinball uses its editor-wide global

--- a/src/vpx/gamedata.rs
+++ b/src/vpx/gamedata.rs
@@ -44,6 +44,14 @@ use bytes::{Buf, BufMut, BytesMut};
 use log::warn;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
+/// VPinball's editor default for per-table detail level. Used as a fallback
+/// when [`GameData::user_detail_level`] is `None`.
+///
+/// VPinball's editor defaults this to 10 (highest detail). The value drives
+/// ramp and rubber tessellation - see
+/// [`crate::vpx::mesh::vpinball_ring_segments`].
+pub const DEFAULT_DETAIL_LEVEL: u32 = 10;
+
 #[derive(Debug, PartialEq, Clone, Copy)]
 #[cfg_attr(test, derive(fake::Dummy))]
 pub enum ViewLayoutMode {
@@ -859,7 +867,23 @@ pub struct GameData {
     /// this has a special quantization,
     /// See [`Self::get_ball_trail_strength`] and [`Self::set_ball_trail_strength`]
     pub ball_trail_strength: Option<u32>, // BTST 93 (became optional in 10.8)
+    /// Per-table detail level override (range `0..=10`, where 10 is the
+    /// highest detail).
+    ///
+    /// VPinball's editor exposes this as the "detail level" slider. It
+    /// drives ramp and rubber tessellation; see
+    /// [`crate::vpx::mesh::vpinball_ring_segments`] for how vpinball
+    /// derives the cross-section segment count from this value.
+    ///
+    /// Only takes effect when [`Self::overwrite_global_detail_level`] is
+    /// `Some(true)`. Otherwise vpinball uses its editor-wide global
+    /// (which a `.vpx` doesn't carry); callers should fall back to
+    /// [`DEFAULT_DETAIL_LEVEL`] in that case - see
+    /// [`Self::effective_detail_level`].
     pub user_detail_level: Option<u32>, // ARAC 94 (became optional in 10.8)
+    /// Whether the table's [`Self::user_detail_level`] should override
+    /// vpinball's editor-global detail level. When `Some(false)` or
+    /// `None`, vpinball ignores the per-table value entirely.
     pub overwrite_global_detail_level: Option<bool>, // OGAC 95 (became optional in 10.8)
     pub overwrite_global_day_night: Option<bool>, // OGDN 96 (became optional in 10.8)
     /// Whether to display the editor grid overlay in the 2D table editor.
@@ -1510,6 +1534,23 @@ impl GameData {
 
     pub fn set_ball_trail_strength(&mut self, value: f32) {
         self.ball_trail_strength = Some(quantize_u8(8, value) as u32);
+    }
+
+    /// Detail level used for ramp/rubber tessellation, mirroring
+    /// vpinball's `PinTable::GetDetailLevel()`:
+    ///
+    /// - When [`Self::overwrite_global_detail_level`] is `Some(true)` the
+    ///   table-stored [`Self::user_detail_level`] is used.
+    /// - Otherwise vpinball would consult its editor-wide setting, which
+    ///   a `.vpx` doesn't carry. We fall back to [`DEFAULT_DETAIL_LEVEL`].
+    pub fn effective_detail_level(&self) -> u32 {
+        if self.overwrite_global_detail_level == Some(true)
+            && let Some(d) = self.user_detail_level
+        {
+            d
+        } else {
+            DEFAULT_DETAIL_LEVEL
+        }
     }
 }
 

--- a/src/vpx/gamedata.rs
+++ b/src/vpx/gamedata.rs
@@ -2349,6 +2349,46 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     #[test]
+    fn effective_detail_level_uses_default_when_no_override() {
+        // overwrite_global_detail_level=None: use DEFAULT_DETAIL_LEVEL,
+        // even if user_detail_level is set (vpinball ignores it then).
+        let g = GameData {
+            user_detail_level: Some(5),
+            overwrite_global_detail_level: None,
+            ..GameData::default()
+        };
+        assert_eq!(g.effective_detail_level(), DEFAULT_DETAIL_LEVEL);
+
+        let g = GameData {
+            overwrite_global_detail_level: Some(false),
+            ..g
+        };
+        assert_eq!(g.effective_detail_level(), DEFAULT_DETAIL_LEVEL);
+    }
+
+    #[test]
+    fn effective_detail_level_uses_table_value_when_override_on() {
+        let g = GameData {
+            user_detail_level: Some(7),
+            overwrite_global_detail_level: Some(true),
+            ..GameData::default()
+        };
+        assert_eq!(g.effective_detail_level(), 7);
+    }
+
+    #[test]
+    fn effective_detail_level_falls_back_when_override_on_but_unset() {
+        // Override flag says "use table value", but the value is None.
+        // Fall back to default rather than panic.
+        let g = GameData {
+            user_detail_level: None,
+            overwrite_global_detail_level: Some(true),
+            ..GameData::default()
+        };
+        assert_eq!(g.effective_detail_level(), DEFAULT_DETAIL_LEVEL);
+    }
+
+    #[test]
     fn read_write_empty() {
         let game_data = GameData::default();
         let version: Version = Version::new(1074);

--- a/src/vpx/mesh/mod.rs
+++ b/src/vpx/mesh/mod.rs
@@ -26,6 +26,45 @@ pub(crate) mod walls;
 #[allow(dead_code)]
 pub const HIT_SHAPE_DETAIL_LEVEL: f32 = 7.0;
 
+/// Compute the cross-section segment count for rubbers and wire ramps,
+/// matching VPinball's `Rubber::GenerateMesh` (rubber.cpp:1235) and
+/// `Ramp::CreateWire` (ramp.cpp:1070):
+///
+/// ```text
+/// int accuracy = detail_level;
+/// if      (accuracy < 5) accuracy = 6;
+/// else if (accuracy < 8) accuracy = 8;
+/// else                   accuracy = (int)((float)accuracy * 1.3f);
+/// if (static_rendering)  accuracy = (int)(10.f * 1.3f);
+/// ```
+///
+/// Numerically these two `(int)(... * 1.3f)` expressions disagree by
+/// one in MSVC's default build: the literal form `(int)(10.f * 1.3f)`
+/// is evaluated on x87 with an 80-bit intermediate (giving 12), while
+/// the variable form `(int)((float)accuracy * 1.3f)` runs in SSE
+/// single-precision (giving 13). `1.3f` is `1.299999952...` in IEEE
+/// 754 f32, so 80-bit yields 12.9999995... -> truncates to 12, while
+/// f32 single-precision rounds to 13.0 exactly -> casts to 13. We
+/// reproduce both paths to match vpinball's output.
+pub fn vpinball_ring_segments(detail_level: u32, static_rendering: bool) -> u32 {
+    let mut accuracy = if detail_level < 5 {
+        6
+    } else if detail_level < 8 {
+        8
+    } else {
+        // SSE-single-precision path: same as Rust's native f32 mult,
+        // which rounds 12.9999995 to 13.0 exactly.
+        (detail_level as f32 * 1.3_f32) as u32
+    };
+    if static_rendering {
+        // x87 80-bit-intermediate path: widen `1.3_f32` to f64 first so
+        // the multiply preserves the f32 value of 1.3 as 1.2999999...,
+        // and the result `12.9999995...` truncates to 12.
+        accuracy = (10.0_f64 * (1.3_f32 as f64)) as u32;
+    }
+    accuracy
+}
+
 /// Convert a detail level (0-10) to an accuracy value for spline subdivision.
 ///
 /// From VPinball rubber.cpp GetCentralCurve():

--- a/src/vpx/mesh/mod.rs
+++ b/src/vpx/mesh/mod.rs
@@ -40,6 +40,7 @@ pub fn vpinball_ring_segments(detail_level: u32, static_rendering: bool) -> u32 
     if static_rendering {
         // VPinball: `accuracy = (int)(10.f * 1.3f);`. MSVC's `/fp:fast`
         // constant folder yields 12; a native f32 multiply yields 13.
+        // Upstream: https://github.com/vpinball/vpinball/issues/3382
         accuracy = 12;
     }
     accuracy

--- a/src/vpx/mesh/mod.rs
+++ b/src/vpx/mesh/mod.rs
@@ -38,31 +38,35 @@ pub const HIT_SHAPE_DETAIL_LEVEL: f32 = 7.0;
 /// if (static_rendering)  accuracy = (int)(10.f * 1.3f);
 /// ```
 ///
-/// Numerically these two `(int)(... * 1.3f)` expressions disagree by
-/// one in MSVC's default build: the literal form `(int)(10.f * 1.3f)`
-/// is evaluated on x87 with an 80-bit intermediate (giving 12), while
-/// the variable form `(int)((float)accuracy * 1.3f)` runs in SSE
-/// single-precision (giving 13). `1.3f` is `1.299999952...` in IEEE
-/// 754 f32, so 80-bit yields 12.9999995... -> truncates to 12, while
-/// f32 single-precision rounds to 13.0 exactly -> casts to 13. We
-/// reproduce both paths to match vpinball's output.
+/// The two `(int)(... * 1.3f)` expressions disagree by one in observed
+/// vpinball output:
+/// - The variable form `(int)((float)accuracy * 1.3f)` matches Rust's
+///   native f32 multiply; for detail level 10 it's `12.9999995...`
+///   which IEEE 754 round-to-even maps to `13.0`, casting to **13**.
+/// - The literal form `(int)(10.f * 1.3f)` is constant-folded by MSVC.
+///   The reference vpinball OBJs we have show **12** for static
+///   rubbers, suggesting MSVC's constant folder ends up with
+///   `12.9999...` (truncates to 12) rather than `13.0`. The exact
+///   mechanism (compile-time evaluator using f32 with x87-style 80-bit
+///   intermediate, or some `/fp:fast`-driven choice) is not verified
+///   from outside MSVC.
+///
+/// We hardcode the static-rendering result as **12** to match the
+/// observed reference output without trying to reproduce MSVC's FP
+/// behaviour. If a future vpinball build ever ships with `13` here,
+/// that's the cue to revisit.
 pub fn vpinball_ring_segments(detail_level: u32, static_rendering: bool) -> u32 {
-    let mut accuracy = if detail_level < 5 {
+    if static_rendering {
+        // See doc above: empirically MSVC folds `(int)(10.f * 1.3f)` to 12.
+        return 12;
+    }
+    if detail_level < 5 {
         6
     } else if detail_level < 8 {
         8
     } else {
-        // SSE-single-precision path: same as Rust's native f32 mult,
-        // which rounds 12.9999995 to 13.0 exactly.
         (detail_level as f32 * 1.3_f32) as u32
-    };
-    if static_rendering {
-        // x87 80-bit-intermediate path: widen `1.3_f32` to f64 first so
-        // the multiply preserves the f32 value of 1.3 as 1.2999999...,
-        // and the result `12.9999995...` truncates to 12.
-        accuracy = (10.0_f64 * (1.3_f32 as f64)) as u32;
     }
-    accuracy
 }
 
 /// Convert a detail level (0-10) to an accuracy value for spline subdivision.
@@ -972,6 +976,61 @@ pub(super) fn closest_point_on_polyline(
     }
 
     best_seg.map(|seg| (best_point, seg))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // VPinball's `Rubber::GenerateMesh` / `Ramp::CreateWire` segment-count
+    // formula. See [`vpinball_ring_segments`]'s doc for the empirical
+    // observations these tests pin down.
+
+    #[test]
+    fn ring_segments_low_detail_clamps_to_six() {
+        // The `< 5` branch hard-floors to 6, matching vpinball.
+        for d in 0..5 {
+            assert_eq!(vpinball_ring_segments(d, false), 6, "non-static d={d}");
+        }
+    }
+
+    #[test]
+    fn ring_segments_mid_detail_clamps_to_eight() {
+        // 5 <= d < 8 produces the literal 8.
+        for d in 5..8 {
+            assert_eq!(vpinball_ring_segments(d, false), 8, "non-static d={d}");
+        }
+    }
+
+    #[test]
+    fn ring_segments_non_static_at_default_detail() {
+        // Variable form `(int)((float)10 * 1.3f)` evaluates to 13.0
+        // exactly in IEEE 754 single-precision, casts to 13. Matches
+        // both Rust's native f32 mult and what we observed for the
+        // single non-static rubber in the JP's Captain Fantastic ref OBJ.
+        assert_eq!(vpinball_ring_segments(10, false), 13);
+    }
+
+    #[test]
+    fn ring_segments_static_at_default_detail() {
+        // Literal form `(int)(10.f * 1.3f)` empirically yields 12 in
+        // vpinball's MSVC build. The f64-widening trick reproduces that
+        // (1.3_f32 -> 1.299999952..._f64 -> 12.999... -> 12).
+        assert_eq!(vpinball_ring_segments(10, true), 12);
+    }
+
+    #[test]
+    fn ring_segments_static_overrides_low_detail() {
+        // The static branch always hits the literal `(int)(10.f * 1.3f)`
+        // expression, regardless of the detail level passed in.
+        for d in 0..=10 {
+            assert_eq!(
+                vpinball_ring_segments(d, true),
+                12,
+                "static d={d} should be overridden to 12"
+            );
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/vpx/mesh/mod.rs
+++ b/src/vpx/mesh/mod.rs
@@ -38,26 +38,30 @@ pub const HIT_SHAPE_DETAIL_LEVEL: f32 = 7.0;
 /// if (static_rendering)  accuracy = (int)(10.f * 1.3f);
 /// ```
 ///
-/// The two `(int)(... * 1.3f)` expressions disagree by one in observed
-/// vpinball output:
-/// - The variable form `(int)((float)accuracy * 1.3f)` matches Rust's
-///   native f32 multiply; for detail level 10 it's `12.9999995...`
-///   which IEEE 754 round-to-even maps to `13.0`, casting to **13**.
-/// - The literal form `(int)(10.f * 1.3f)` is constant-folded by MSVC.
-///   The reference vpinball OBJs we have show **12** for static
-///   rubbers, suggesting MSVC's constant folder ends up with
-///   `12.9999...` (truncates to 12) rather than `13.0`. The exact
-///   mechanism (compile-time evaluator using f32 with x87-style 80-bit
-///   intermediate, or some `/fp:fast`-driven choice) is not verified
-///   from outside MSVC.
+/// The two `(int)(... * 1.3f)` expressions evaluate differently in
+/// MSVC, verified on `cl.exe 19.44 /fp:fast /arch:SSE2 x64` (vpinball's
+/// build flags - see `make/CMakeLists_bgfx-windows-x86.txt`):
 ///
-/// We hardcode the static-rendering result as **12** to match the
-/// observed reference output without trying to reproduce MSVC's FP
-/// behaviour. If a future vpinball build ever ships with `13` here,
-/// that's the cue to revisit.
+/// ```text
+/// static     (int)(10.f * 1.3f)         = 12
+/// non-static (int)((float)10 * 1.3f)    = 13
+/// ```
+///
+/// Both `10.f * 1.3f` and `(float)10 * 1.3f` produce `13.0` exactly
+/// in IEEE 754 f32 (round-to-nearest-even rounds `12.9999995...` up
+/// to `13.0`), so when stored to a float variable and printed, both
+/// read `13.00000000000000000000`. But `/fp:fast`'s constant folder
+/// evaluates the *literal* expression `(int)(10.f * 1.3f)` with a
+/// higher-precision intermediate and truncates to **12**. The
+/// runtime-evaluated variable form goes through SSE single-precision
+/// and casts to **13**.
+///
+/// We hardcode the static-rendering result as **12** to match. The
+/// non-static branch's native f32 multiply matches MSVC's runtime
+/// SSE behaviour exactly.
 pub fn vpinball_ring_segments(detail_level: u32, static_rendering: bool) -> u32 {
     if static_rendering {
-        // See doc above: empirically MSVC folds `(int)(10.f * 1.3f)` to 12.
+        // MSVC `/fp:fast` folds `(int)(10.f * 1.3f)` to 12 (verified).
         return 12;
     }
     if detail_level < 5 {

--- a/src/vpx/mesh/mod.rs
+++ b/src/vpx/mesh/mod.rs
@@ -27,7 +27,7 @@ pub(crate) mod walls;
 pub const HIT_SHAPE_DETAIL_LEVEL: f32 = 7.0;
 
 /// Compute the cross-section segment count for rubbers and wire ramps,
-/// matching VPinball's `Rubber::GenerateMesh` (rubber.cpp:1235) and
+/// mirroring VPinball's `Rubber::GenerateMesh` (rubber.cpp:1235) and
 /// `Ramp::CreateWire` (ramp.cpp:1070):
 ///
 /// ```text
@@ -38,39 +38,39 @@ pub const HIT_SHAPE_DETAIL_LEVEL: f32 = 7.0;
 /// if (static_rendering)  accuracy = (int)(10.f * 1.3f);
 /// ```
 ///
-/// The two `(int)(... * 1.3f)` expressions evaluate differently in
-/// MSVC, verified on `cl.exe 19.44 /fp:fast /arch:SSE2 x64` (vpinball's
-/// build flags - see `make/CMakeLists_bgfx-windows-x86.txt`):
+/// MSVC's two `(int)(... * 1.3f)` expressions evaluate differently
+/// even though they appear identical in source. Verified on `cl.exe
+/// 19.44 /fp:fast /arch:SSE2 x64` (vpinball's build flags):
 ///
 /// ```text
-/// static     (int)(10.f * 1.3f)         = 12
-/// non-static (int)((float)10 * 1.3f)    = 13
+/// (int)((float)10 * 1.3f)   // runtime SSE single-precision -> 13
+/// (int)(10.f * 1.3f)        // /fp:fast constant fold        -> 12
 /// ```
 ///
-/// Both `10.f * 1.3f` and `(float)10 * 1.3f` produce `13.0` exactly
-/// in IEEE 754 f32 (round-to-nearest-even rounds `12.9999995...` up
-/// to `13.0`), so when stored to a float variable and printed, both
-/// read `13.00000000000000000000`. But `/fp:fast`'s constant folder
-/// evaluates the *literal* expression `(int)(10.f * 1.3f)` with a
-/// higher-precision intermediate and truncates to **12**. The
-/// runtime-evaluated variable form goes through SSE single-precision
-/// and casts to **13**.
+/// Both `10.f * 1.3f` and `(float)10 * 1.3f` round to `13.0` exactly
+/// when stored to an f32 (IEEE 754 round-to-nearest-even rounds
+/// 12.9999995 up). But `/fp:fast`'s constant folder evaluates the
+/// literal expression with a higher-precision intermediate and
+/// truncates to **12** when cast directly to int.
 ///
-/// We hardcode the static-rendering result as **12** to match. The
-/// non-static branch's native f32 multiply matches MSVC's runtime
-/// SSE behaviour exactly.
+/// Rust's f32 multiply matches MSVC's runtime SSE path (`13`), so the
+/// non-static branch is a direct port. The static-override expression
+/// has to be hardcoded to **12** because Rust has no equivalent to
+/// MSVC's `/fp:fast` constant folder.
 pub fn vpinball_ring_segments(detail_level: u32, static_rendering: bool) -> u32 {
-    if static_rendering {
-        // MSVC `/fp:fast` folds `(int)(10.f * 1.3f)` to 12 (verified).
-        return 12;
-    }
-    if detail_level < 5 {
+    let mut accuracy = if detail_level < 5 {
         6
     } else if detail_level < 8 {
         8
     } else {
+        // VPinball: `accuracy = (int)((float)accuracy * 1.3f);`
         (detail_level as f32 * 1.3_f32) as u32
+    };
+    if static_rendering {
+        // VPinball: `accuracy = (int)(10.f * 1.3f);` -- MSVC folds to 12.
+        accuracy = 12;
     }
+    accuracy
 }
 
 /// Convert a detail level (0-10) to an accuracy value for spline subdivision.

--- a/src/vpx/mesh/mod.rs
+++ b/src/vpx/mesh/mod.rs
@@ -26,48 +26,20 @@ pub(crate) mod walls;
 #[allow(dead_code)]
 pub const HIT_SHAPE_DETAIL_LEVEL: f32 = 7.0;
 
-/// Compute the cross-section segment count for rubbers and wire ramps,
-/// mirroring VPinball's `Rubber::GenerateMesh` (rubber.cpp:1235) and
-/// `Ramp::CreateWire` (ramp.cpp:1070):
-///
-/// ```text
-/// int accuracy = detail_level;
-/// if      (accuracy < 5) accuracy = 6;
-/// else if (accuracy < 8) accuracy = 8;
-/// else                   accuracy = (int)((float)accuracy * 1.3f);
-/// if (static_rendering)  accuracy = (int)(10.f * 1.3f);
-/// ```
-///
-/// MSVC's two `(int)(... * 1.3f)` expressions evaluate differently
-/// even though they appear identical in source. Verified on `cl.exe
-/// 19.44 /fp:fast /arch:SSE2 x64` (vpinball's build flags):
-///
-/// ```text
-/// (int)((float)10 * 1.3f)   // runtime SSE single-precision -> 13
-/// (int)(10.f * 1.3f)        // /fp:fast constant fold        -> 12
-/// ```
-///
-/// Both `10.f * 1.3f` and `(float)10 * 1.3f` round to `13.0` exactly
-/// when stored to an f32 (IEEE 754 round-to-nearest-even rounds
-/// 12.9999995 up). But `/fp:fast`'s constant folder evaluates the
-/// literal expression with a higher-precision intermediate and
-/// truncates to **12** when cast directly to int.
-///
-/// Rust's f32 multiply matches MSVC's runtime SSE path (`13`), so the
-/// non-static branch is a direct port. The static-override expression
-/// has to be hardcoded to **12** because Rust has no equivalent to
-/// MSVC's `/fp:fast` constant folder.
+/// Cross-section segment count for rubbers and wire ramps, mirroring
+/// VPinball's `Rubber::GenerateMesh` (rubber.cpp:1235) and
+/// `Ramp::CreateWire` (ramp.cpp:1070).
 pub fn vpinball_ring_segments(detail_level: u32, static_rendering: bool) -> u32 {
     let mut accuracy = if detail_level < 5 {
         6
     } else if detail_level < 8 {
         8
     } else {
-        // VPinball: `accuracy = (int)((float)accuracy * 1.3f);`
         (detail_level as f32 * 1.3_f32) as u32
     };
     if static_rendering {
-        // VPinball: `accuracy = (int)(10.f * 1.3f);` -- MSVC folds to 12.
+        // VPinball: `accuracy = (int)(10.f * 1.3f);`. MSVC's `/fp:fast`
+        // constant folder yields 12; a native f32 multiply yields 13.
         accuracy = 12;
     }
     accuracy

--- a/src/vpx/mesh/ramps.rs
+++ b/src/vpx/mesh/ramps.rs
@@ -473,6 +473,7 @@ fn build_wire_ramp_mesh(
     ramp: &Ramp,
     vvertex: &[RenderVertex3D],
     detail_level: u32,
+    material_opacity_active: bool,
 ) -> Option<(Vec<VertexWrapper>, Vec<VpxFace>)> {
     let (rgv_local, rgheight, _) = get_ramp_vertex(ramp, vvertex, false);
     let num_rings = vvertex.len();
@@ -481,12 +482,12 @@ fn build_wire_ramp_mesh(
         return None;
     }
 
-    // VPinball's `Ramp::CreateWire` derives `numSegments` from the table's
-    // detail level (ramp.cpp:1070). vpin doesn't yet parse the ramp's
-    // `m_d.m_staticRendering` field, so we default it to `true` - the
-    // typical setting and the only one that produces the f32-truncation
-    // result of 12 at any detail level. TODO: parse ramp static_rendering.
-    let num_segments = super::vpinball_ring_segments(detail_level, true) as usize;
+    // VPinball's `Ramp::GenerateWireMesh` (ramp.cpp:1063-1065) overrides
+    // the segment count to max precision when the material is opaque
+    // (`!mat->m_bOpacityActive`). Pass that as the
+    // `static_rendering`-equivalent flag to `vpinball_ring_segments`.
+    let num_segments =
+        super::vpinball_ring_segments(detail_level, !material_opacity_active) as usize;
 
     // Get middle points (center of ramp)
     let mut mid_points: Vec<Vec2> = Vec::with_capacity(num_rings);
@@ -783,11 +784,18 @@ pub(crate) fn get_ramp_surface_height(ramp: &Ramp, x: f32, y: f32) -> f32 {
     }
 }
 
-/// Build the complete ramp mesh
+/// Build the complete ramp mesh.
+///
+/// `material_opacity_active` mirrors VPinball's `mat->m_bOpacityActive`
+/// for the ramp's material. VPinball's `Ramp::GenerateWireMesh`
+/// (ramp.cpp:1067) bumps the wire-cross-section segment count to its
+/// max precision when the material is **opaque** (not opacity-active);
+/// transparent ramps fall through to the detail-level formula.
 pub(crate) fn build_ramp_mesh(
     ramp: &Ramp,
     table_dims: &TableDimensions,
     detail_level: u32,
+    material_opacity_active: bool,
 ) -> Option<(Vec<VertexWrapper>, Vec<VpxFace>)> {
     // Generate meshes for all ramps, including invisible ones
     // This is useful for tools that need to visualize or process all geometry
@@ -806,7 +814,7 @@ pub(crate) fn build_ramp_mesh(
     }
 
     if is_habitrail(ramp) {
-        build_wire_ramp_mesh(ramp, &vvertex, detail_level)
+        build_wire_ramp_mesh(ramp, &vvertex, detail_level, material_opacity_active)
     } else {
         build_flat_ramp_mesh(ramp, &vvertex, table_dims)
     }
@@ -890,6 +898,7 @@ mod tests {
             &ramp,
             &TableDimensions::new(0.0, 0.0, 1000.0, 2000.0),
             crate::vpx::gamedata::DEFAULT_DETAIL_LEVEL,
+            false, // material_opacity_active: assume opaque
         );
         assert!(result.is_some());
 
@@ -935,6 +944,7 @@ mod tests {
             &ramp,
             &TableDimensions::new(0.0, 0.0, 1000.0, 2000.0),
             crate::vpx::gamedata::DEFAULT_DETAIL_LEVEL,
+            false, // material_opacity_active: assume opaque
         );
         assert!(result.is_some(), "One-wire ramp should generate mesh");
 
@@ -993,6 +1003,7 @@ mod tests {
             &ramp,
             &TableDimensions::new(0.0, 0.0, 1000.0, 2000.0),
             crate::vpx::gamedata::DEFAULT_DETAIL_LEVEL,
+            false, // material_opacity_active: assume opaque
         );
         assert!(result.is_some(), "One-wire ramp should generate mesh");
 

--- a/src/vpx/mesh/ramps.rs
+++ b/src/vpx/mesh/ramps.rs
@@ -472,6 +472,7 @@ fn create_wire(
 fn build_wire_ramp_mesh(
     ramp: &Ramp,
     vvertex: &[RenderVertex3D],
+    detail_level: u32,
 ) -> Option<(Vec<VertexWrapper>, Vec<VpxFace>)> {
     let (rgv_local, rgheight, _) = get_ramp_vertex(ramp, vvertex, false);
     let num_rings = vvertex.len();
@@ -481,10 +482,11 @@ fn build_wire_ramp_mesh(
     }
 
     // VPinball's `Ramp::CreateWire` derives `numSegments` from the table's
-    // detail level: at the typical default (detail level 10, static
-    // rendering on) the formula `(int)(10.0f * 1.3f)` yields 12 due to
-    // f32 rounding (1.3f -> 1.2999999...). Hardcode 12 to match.
-    let num_segments = 12;
+    // detail level (ramp.cpp:1070). vpin doesn't yet parse the ramp's
+    // `m_d.m_staticRendering` field, so we default it to `true` - the
+    // typical setting and the only one that produces the f32-truncation
+    // result of 12 at any detail level. TODO: parse ramp static_rendering.
+    let num_segments = super::vpinball_ring_segments(detail_level, true) as usize;
 
     // Get middle points (center of ramp)
     let mut mid_points: Vec<Vec2> = Vec::with_capacity(num_rings);
@@ -785,6 +787,7 @@ pub(crate) fn get_ramp_surface_height(ramp: &Ramp, x: f32, y: f32) -> f32 {
 pub(crate) fn build_ramp_mesh(
     ramp: &Ramp,
     table_dims: &TableDimensions,
+    detail_level: u32,
 ) -> Option<(Vec<VertexWrapper>, Vec<VpxFace>)> {
     // Generate meshes for all ramps, including invisible ones
     // This is useful for tools that need to visualize or process all geometry
@@ -803,7 +806,7 @@ pub(crate) fn build_ramp_mesh(
     }
 
     if is_habitrail(ramp) {
-        build_wire_ramp_mesh(ramp, &vvertex)
+        build_wire_ramp_mesh(ramp, &vvertex, detail_level)
     } else {
         build_flat_ramp_mesh(ramp, &vvertex, table_dims)
     }
@@ -883,7 +886,11 @@ mod tests {
             ..Default::default()
         };
 
-        let result = build_ramp_mesh(&ramp, &TableDimensions::new(0.0, 0.0, 1000.0, 2000.0));
+        let result = build_ramp_mesh(
+            &ramp,
+            &TableDimensions::new(0.0, 0.0, 1000.0, 2000.0),
+            crate::vpx::gamedata::DEFAULT_DETAIL_LEVEL,
+        );
         assert!(result.is_some());
 
         let (vertices, indices) = result.unwrap();
@@ -924,7 +931,11 @@ mod tests {
             ..Default::default()
         };
 
-        let result = build_ramp_mesh(&ramp, &TableDimensions::new(0.0, 0.0, 1000.0, 2000.0));
+        let result = build_ramp_mesh(
+            &ramp,
+            &TableDimensions::new(0.0, 0.0, 1000.0, 2000.0),
+            crate::vpx::gamedata::DEFAULT_DETAIL_LEVEL,
+        );
         assert!(result.is_some(), "One-wire ramp should generate mesh");
 
         let (vertices, indices) = result.unwrap();
@@ -933,7 +944,9 @@ mod tests {
 
         // With smoothing, we should have more than 3 rings (original control points)
         // The exact number depends on accuracy, but should be > 3 due to subdivision
-        let num_segments = 12;
+        let num_segments =
+            super::super::vpinball_ring_segments(crate::vpx::gamedata::DEFAULT_DETAIL_LEVEL, true)
+                as usize;
         let num_vertices = vertices.len();
         let num_rings = num_vertices / num_segments;
         assert!(
@@ -976,7 +989,11 @@ mod tests {
             ..Default::default()
         };
 
-        let result = build_ramp_mesh(&ramp, &TableDimensions::new(0.0, 0.0, 1000.0, 2000.0));
+        let result = build_ramp_mesh(
+            &ramp,
+            &TableDimensions::new(0.0, 0.0, 1000.0, 2000.0),
+            crate::vpx::gamedata::DEFAULT_DETAIL_LEVEL,
+        );
         assert!(result.is_some(), "One-wire ramp should generate mesh");
 
         let (vertices, _) = result.unwrap();

--- a/src/vpx/mesh/ramps.rs
+++ b/src/vpx/mesh/ramps.rs
@@ -480,8 +480,11 @@ fn build_wire_ramp_mesh(
         return None;
     }
 
-    // Determine accuracy/segments based on detail level (use 8 as default)
-    let num_segments = 8;
+    // VPinball's `Ramp::CreateWire` derives `numSegments` from the table's
+    // detail level: at the typical default (detail level 10, static
+    // rendering on) the formula `(int)(10.0f * 1.3f)` yields 12 due to
+    // f32 rounding (1.3f -> 1.2999999...). Hardcode 12 to match.
+    let num_segments = 12;
 
     // Get middle points (center of ramp)
     let mut mid_points: Vec<Vec2> = Vec::with_capacity(num_rings);
@@ -930,7 +933,7 @@ mod tests {
 
         // With smoothing, we should have more than 3 rings (original control points)
         // The exact number depends on accuracy, but should be > 3 due to subdivision
-        let num_segments = 8;
+        let num_segments = 12;
         let num_vertices = vertices.len();
         let num_rings = num_vertices / num_segments;
         assert!(

--- a/src/vpx/mesh/rubbers.rs
+++ b/src/vpx/mesh/rubbers.rs
@@ -126,8 +126,11 @@ fn generate_mesh(rubber: &Rubber) -> Option<(Vec<Vertex3dNoTex2>, Vec<u32>)> {
         return None;
     }
 
-    // Use 8 segments for the circular cross-section (similar to wire ramps)
-    let num_segments = 8;
+    // VPinball's `Rubber::GenerateMesh` derives `numSegments` from the
+    // table's detail level: at the typical default (detail level 10,
+    // static rendering on) the formula `(int)(10.0f * 1.3f)` yields 12
+    // due to f32 rounding (1.3f -> 1.2999999...). Hardcode 12 to match.
+    let num_segments = 12;
 
     let num_vertices = num_rings * num_segments;
     let num_indices = 6 * num_vertices;
@@ -596,7 +599,7 @@ mod tests {
         // For a smooth rubber, adjacent vertices should have similar normals
         // (indicating smooth shading, not flat shading with hard edges)
         // We check vertices that are on the same ring (same position along the rubber)
-        let num_segments = 8; // Cross-section segments
+        let num_segments = 12; // Cross-section segments
 
         // Check the first ring of vertices
         if verts.len() >= num_segments * 2 {
@@ -754,7 +757,7 @@ mod tests {
         assert!(result.is_some(), "Ring003 rubber mesh should be generated");
 
         let (vertices, indices, _center) = result.unwrap();
-        let num_segments = 8; // Cross-section segments
+        let num_segments = 12; // Cross-section segments
         let num_rings = vertices.len() / num_segments;
 
         println!("Ring003 rubber:");

--- a/src/vpx/mesh/rubbers.rs
+++ b/src/vpx/mesh/rubbers.rs
@@ -111,7 +111,7 @@ fn get_spline_vertex(
 
 /// Generate the rubber mesh
 /// This is a port of Rubber::GenerateMesh from rubber.cpp
-fn generate_mesh(rubber: &Rubber) -> Option<(Vec<Vertex3dNoTex2>, Vec<u32>)> {
+fn generate_mesh(rubber: &Rubber, detail_level: u32) -> Option<(Vec<Vertex3dNoTex2>, Vec<u32>)> {
     // From VPinball rubber.cpp GetCentralCurve():
     // accuracy = 4.0f * powf(10.0f, (10.0f - accuracy) * (1.0f / 1.5f))
     // where detail_level=10 gives 4.0 (highest detail), detail_level=0 gives ~18,000,000 (lowest detail)
@@ -126,11 +126,8 @@ fn generate_mesh(rubber: &Rubber) -> Option<(Vec<Vertex3dNoTex2>, Vec<u32>)> {
         return None;
     }
 
-    // VPinball's `Rubber::GenerateMesh` derives `numSegments` from the
-    // table's detail level: at the typical default (detail level 10,
-    // static rendering on) the formula `(int)(10.0f * 1.3f)` yields 12
-    // due to f32 rounding (1.3f -> 1.2999999...). Hardcode 12 to match.
-    let num_segments = 12;
+    let num_segments =
+        super::vpinball_ring_segments(detail_level, rubber.static_rendering) as usize;
 
     let num_vertices = num_rings * num_segments;
     let num_indices = 6 * num_vertices;
@@ -375,6 +372,7 @@ fn apply_rotation(
 /// Center is (x, y, z) in VPX coordinates.
 pub(crate) fn build_rubber_mesh(
     rubber: &Rubber,
+    detail_level: u32,
 ) -> Option<(Vec<VertexWrapper>, Vec<VpxFace>, Vec3)> {
     if rubber.thickness == 0 {
         return None;
@@ -384,7 +382,7 @@ pub(crate) fn build_rubber_mesh(
         return None;
     }
 
-    let (mut vertices, indices) = generate_mesh(rubber)?;
+    let (mut vertices, indices) = generate_mesh(rubber, detail_level)?;
 
     // Apply rotation transformation and get center position
     let center = apply_rotation(
@@ -507,7 +505,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = build_rubber_mesh(&rubber);
+        let result = build_rubber_mesh(&rubber, crate::vpx::gamedata::DEFAULT_DETAIL_LEVEL);
         assert!(result.is_some());
 
         let (vertices, indices, _center) = result.unwrap();
@@ -554,7 +552,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = build_rubber_mesh(&rubber);
+        let result = build_rubber_mesh(&rubber, crate::vpx::gamedata::DEFAULT_DETAIL_LEVEL);
         assert!(result.is_some());
 
         let (vertices, indices, _center) = result.unwrap();
@@ -575,7 +573,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = build_rubber_mesh(&rubber);
+        let result = build_rubber_mesh(&rubber, crate::vpx::gamedata::DEFAULT_DETAIL_LEVEL);
         assert!(result.is_some(), "Octagon rubber mesh should be generated");
 
         let (vertices, indices, _center) = result.unwrap();
@@ -599,7 +597,11 @@ mod tests {
         // For a smooth rubber, adjacent vertices should have similar normals
         // (indicating smooth shading, not flat shading with hard edges)
         // We check vertices that are on the same ring (same position along the rubber)
-        let num_segments = 12; // Cross-section segments
+        // VPinball's formula for detail level 10 + static_rendering=true gives
+        // `(int)(10.0f * 1.3f)` segments. In Rust's f32 this evaluates to 13.
+        let num_segments =
+            super::super::vpinball_ring_segments(crate::vpx::gamedata::DEFAULT_DETAIL_LEVEL, true)
+                as usize;
 
         // Check the first ring of vertices
         if verts.len() >= num_segments * 2 {
@@ -664,7 +666,7 @@ mod tests {
             ..Default::default()
         };
 
-        let result = build_rubber_mesh(&rubber);
+        let result = build_rubber_mesh(&rubber, crate::vpx::gamedata::DEFAULT_DETAIL_LEVEL);
         assert!(
             result.is_some(),
             "Sharp octagon rubber mesh should be generated"
@@ -753,11 +755,13 @@ mod tests {
             ..Default::default()
         };
 
-        let result = build_rubber_mesh(&rubber);
+        let result = build_rubber_mesh(&rubber, crate::vpx::gamedata::DEFAULT_DETAIL_LEVEL);
         assert!(result.is_some(), "Ring003 rubber mesh should be generated");
 
         let (vertices, indices, _center) = result.unwrap();
-        let num_segments = 12; // Cross-section segments
+        let num_segments =
+            super::super::vpinball_ring_segments(crate::vpx::gamedata::DEFAULT_DETAIL_LEVEL, true)
+                as usize;
         let num_rings = vertices.len() / num_segments;
 
         println!("Ring003 rubber:");

--- a/src/vpx/mesh/walls.rs
+++ b/src/vpx/mesh/walls.rs
@@ -506,52 +506,66 @@ fn build_top_mesh(
     }
 }
 
+/// Triangulate a simple 2D polygon, mirroring vpinball's
+/// `PolygonToTriangles` + `AdvancePoint` (`MeshUtils.h:496`).
+///
+/// The algorithm is ear-clipping with two extra checks per candidate ear:
+///
+/// 1. The new triangle's interior angle (`a`-`b`-`c`) must not be
+///    concave (`GetDot(pv1, pv2, pv3) >= 0`).
+/// 2. The new diagonal `a`-`c` must not intersect any remaining
+///    polygon edge.
+///
+/// The standard "convex vertex + no point in triangle" check used by
+/// the previous implementation rejects valid ears on some polygons
+/// where an adjacent vertex sits exactly on a triangle edge or where
+/// the polygon has near-collinear edges. The diagonal-intersection
+/// test is the more robust criterion vpinball uses.
+///
+/// Mirrors `surface.cpp:622`'s call (`support_both_winding_orders =
+/// false`) - we don't pre-flip the winding because vpin's wall render
+/// vertices come from the same `IHaveDragPoints::GetRgVertex` port and
+/// are produced in the expected CCW orientation.
 fn triangulate_polygon(points: &[(f32, f32)]) -> Vec<[u32; 3]> {
     if points.len() < 3 {
         return Vec::new();
     }
 
-    let mut indices = (0..points.len()).collect::<Vec<_>>();
-    if signed_area(points) < 0.0 {
-        indices.reverse();
+    // VPinball's algorithm expects polygons in its conventional vertex
+    // order (vpinball-CCW, which is math-CW because the table Y axis
+    // points down). If the input is in math-CCW order, reverse it -
+    // this mirrors `support_both_winding_orders = true` in vpinball's
+    // `PolygonToTriangles`.
+    let mut vpoly: Vec<u32> = (0..points.len() as u32).collect();
+    if signed_area(points) > 0.0 {
+        vpoly.reverse();
     }
+    let tricount = points.len() - 2;
+    let mut triangles = Vec::with_capacity(tricount);
 
-    let mut triangles = Vec::new();
-    let mut guard = 0usize;
-    while indices.len() >= 3 && guard < points.len() * points.len() {
-        guard += 1;
-        let mut ear_found = false;
-        for i in 0..indices.len() {
-            let prev = indices[(i + indices.len() - 1) % indices.len()];
-            let curr = indices[i];
-            let next = indices[(i + 1) % indices.len()];
+    for _ in 0..tricount {
+        let mut found = false;
+        for i in 0..vpoly.len() {
+            let s = vpoly.len();
+            let pre = vpoly[if i == 0 { s - 1 } else { i - 1 }];
+            let a = vpoly[i];
+            let b = vpoly[if i < s - 1 { i + 1 } else { 0 }];
+            let c = vpoly[if i < s - 2 { i + 2 } else { i + 2 - s }];
+            let post = vpoly[if i < s - 3 { i + 3 } else { i + 3 - s }];
 
-            if !is_convex(points[prev], points[curr], points[next]) {
+            if !advance_point(points, &vpoly, a, b, c, pre, post) {
                 continue;
             }
 
-            let mut contains = false;
-            for &other in &indices {
-                if other == prev || other == curr || other == next {
-                    continue;
-                }
-                if point_in_triangle(points[other], points[prev], points[curr], points[next]) {
-                    contains = true;
-                    break;
-                }
-            }
-
-            if contains {
-                continue;
-            }
-
-            triangles.push([prev as u32, curr as u32, next as u32]);
-            indices.remove(i);
-            ear_found = true;
+            // VPinball emits the triangle as (a, c, b).
+            triangles.push([a, c, b]);
+            vpoly.remove(if i < s - 1 { i + 1 } else { 0 });
+            found = true;
             break;
         }
-
-        if !ear_found {
+        if !found {
+            // No valid ear in this sweep - matches vpinball, which also
+            // silently skips this iteration rather than recovering.
             break;
         }
     }
@@ -559,6 +573,67 @@ fn triangulate_polygon(points: &[(f32, f32)]) -> Vec<[u32; 3]> {
     triangles
 }
 
+/// Mirrors vpinball's `AdvancePoint` (`MeshUtils.h`).
+fn advance_point(
+    rgv: &[(f32, f32)],
+    vpoly: &[u32],
+    a: u32,
+    b: u32,
+    c: u32,
+    pre: u32,
+    post: u32,
+) -> bool {
+    let pv1 = rgv[a as usize];
+    let pv2 = rgv[b as usize];
+    let pv3 = rgv[c as usize];
+    let pv_pre = rgv[pre as usize];
+    let pv_post = rgv[post as usize];
+
+    if dot_2d(pv1, pv2, pv3) < 0.0
+        || (dot_2d(pv_pre, pv1, pv2) > 0.0 && dot_2d(pv_pre, pv1, pv3) < 0.0)
+        || (dot_2d(pv2, pv3, pv_post) > 0.0 && dot_2d(pv1, pv3, pv_post) < 0.0)
+    {
+        return false;
+    }
+
+    // Bounding-box of the diagonal a-c, used by vpinball as a fast
+    // reject before the full segment-intersection test.
+    let minx = pv1.0.min(pv3.0);
+    let maxx = pv1.0.max(pv3.0);
+    let miny = pv1.1.min(pv3.1);
+    let maxy = pv1.1.max(pv3.1);
+
+    for i in 0..vpoly.len() {
+        let v1 = rgv[vpoly[i] as usize];
+        let v2 = rgv[vpoly[if i < vpoly.len() - 1 { i + 1 } else { 0 }] as usize];
+
+        // Skip edges that share a vertex with the diagonal.
+        if v1 == pv1 || v2 == pv1 || v1 == pv3 || v2 == pv3 {
+            continue;
+        }
+        // VPinball's bounding-box reject (with the original `pvCross2->y
+        // <= maxx` typo carried verbatim - see MeshUtils.h).
+        if !((v1.1 >= miny || v2.1 >= miny)
+            && (v1.1 <= maxy || v2.1 <= maxy)
+            && (v1.0 >= minx || v2.0 >= minx)
+            && (v1.0 <= maxx || v2.1 <= maxx))
+        {
+            continue;
+        }
+        if lines_intersect(pv1, pv3, v1, v2) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Mirrors vpinball's `GetDot` (`MeshUtils.h`):
+/// `(joint.x - end1.x) * (joint.y - end2.y) - (joint.y - end1.y) * (joint.x - end2.x)`.
+fn dot_2d(end1: (f32, f32), joint: (f32, f32), end2: (f32, f32)) -> f32 {
+    (joint.0 - end1.0) * (joint.1 - end2.1) - (joint.1 - end1.1) * (joint.0 - end2.0)
+}
+
+/// Twice the signed polygon area; positive = math-CCW orientation.
 fn signed_area(points: &[(f32, f32)]) -> f32 {
     let mut area = 0.0;
     for i in 0..points.len() {
@@ -566,40 +641,43 @@ fn signed_area(points: &[(f32, f32)]) -> f32 {
         let (x2, y2) = points[(i + 1) % points.len()];
         area += x1 * y2 - x2 * y1;
     }
-    area * 0.5
+    area
 }
 
-fn is_convex(a: (f32, f32), b: (f32, f32), c: (f32, f32)) -> bool {
-    let abx = b.0 - a.0;
-    let aby = b.1 - a.1;
-    let bcx = c.0 - b.0;
-    let bcy = c.1 - b.1;
-    (abx * bcy - aby * bcx) > 0.0
-}
+/// Mirrors vpinball's `FLinesIntersect` (`MeshUtils.h`). Returns true
+/// iff segment `(s1, s2)` intersects segment `(e1, e2)`. The collinear
+/// branches mirror vpinball's choice to compare only the X coordinate.
+fn lines_intersect(s1: (f32, f32), s2: (f32, f32), e1: (f32, f32), e2: (f32, f32)) -> bool {
+    let (x1, y1) = s1;
+    let (x2, y2) = s2;
+    let (x3, y3) = e1;
+    let (x4, y4) = e2;
 
-fn point_in_triangle(p: (f32, f32), a: (f32, f32), b: (f32, f32), c: (f32, f32)) -> bool {
-    let v0x = c.0 - a.0;
-    let v0y = c.1 - a.1;
-    let v1x = b.0 - a.0;
-    let v1y = b.1 - a.1;
-    let v2x = p.0 - a.0;
-    let v2y = p.1 - a.1;
+    let d123 = (x2 - x1) * (y3 - y1) - (x3 - x1) * (y2 - y1);
+    if d123 == 0.0 {
+        return x3 >= x1.min(x2) && x3 <= x2.max(x1);
+    }
 
-    let dot00 = v0x * v0x + v0y * v0y;
-    let dot01 = v0x * v1x + v0y * v1y;
-    let dot02 = v0x * v2x + v0y * v2y;
-    let dot11 = v1x * v1x + v1y * v1y;
-    let dot12 = v1x * v2x + v1y * v2y;
+    let d124 = (x2 - x1) * (y4 - y1) - (x4 - x1) * (y2 - y1);
+    if d124 == 0.0 {
+        return x4 >= x1.min(x2) && x4 <= x2.max(x1);
+    }
 
-    let denom = dot00 * dot11 - dot01 * dot01;
-    if denom == 0.0 {
+    if d123 * d124 >= 0.0 {
         return false;
     }
-    let inv_denom = 1.0 / denom;
-    let u = (dot11 * dot02 - dot01 * dot12) * inv_denom;
-    let v = (dot00 * dot12 - dot01 * dot02) * inv_denom;
 
-    u >= 0.0 && v >= 0.0 && (u + v) <= 1.0
+    let d341 = (x3 - x1) * (y4 - y1) - (x4 - x1) * (y3 - y1);
+    if d341 == 0.0 {
+        return x1 >= x3.min(x4) && x1 <= x3.max(x4);
+    }
+
+    let d342 = d123 - d124 + d341;
+    if d342 == 0.0 {
+        return x2 >= x3.min(x4) && x2 <= x3.max(x4);
+    }
+
+    d341 * d342 < 0.0
 }
 
 #[cfg(test)]

--- a/src/vpx/mesh/walls.rs
+++ b/src/vpx/mesh/walls.rs
@@ -684,10 +684,118 @@ fn lines_intersect(s1: (f32, f32), s2: (f32, f32), e1: (f32, f32), e2: (f32, f32
 mod tests {
     use super::*;
 
+    /// Helper: walk all triangles, accumulate signed area, return its
+    /// absolute value. Should equal the absolute polygon area when the
+    /// triangulation is complete and non-overlapping.
+    fn triangulated_area(points: &[(f32, f32)], tris: &[[u32; 3]]) -> f32 {
+        let mut a = 0.0_f32;
+        for tri in tris {
+            let p0 = points[tri[0] as usize];
+            let p1 = points[tri[1] as usize];
+            let p2 = points[tri[2] as usize];
+            a += ((p1.0 - p0.0) * (p2.1 - p0.1) - (p2.0 - p0.0) * (p1.1 - p0.1)).abs() * 0.5;
+        }
+        a
+    }
+
+    fn polygon_area(points: &[(f32, f32)]) -> f32 {
+        signed_area(points).abs() * 0.5
+    }
+
     #[test]
     fn triangulates_square() {
+        // CCW square (math convention). The algorithm auto-flips to
+        // vpinball-CCW (= math-CW) and produces 2 triangles.
         let points = vec![(0.0, 0.0), (1.0, 0.0), (1.0, 1.0), (0.0, 1.0)];
         let tris = triangulate_polygon(&points);
         assert_eq!(tris.len(), 2);
+        assert!((triangulated_area(&points, &tris) - polygon_area(&points)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn triangulates_clockwise_square_too() {
+        // CW square (vpinball-native winding). No flip applied; should
+        // still produce 2 triangles.
+        let points = vec![(0.0, 0.0), (0.0, 1.0), (1.0, 1.0), (1.0, 0.0)];
+        let tris = triangulate_polygon(&points);
+        assert_eq!(tris.len(), 2);
+        assert!((triangulated_area(&points, &tris) - polygon_area(&points)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn triangulates_concave_l_shape() {
+        // L-shape (concave). The previous "convex ear + point in
+        // triangle" algorithm could mis-classify ears here; the
+        // vpinball-faithful AdvancePoint port should always produce
+        // n - 2 = 4 triangles covering the full area.
+        //
+        //   (0,2)---(1,2)
+        //     |       |
+        //     |       |   (CCW)
+        //     |       (1,1)----(2,1)
+        //     |                  |
+        //   (0,0)--------------(2,0)
+        let points = vec![
+            (0.0, 0.0),
+            (2.0, 0.0),
+            (2.0, 1.0),
+            (1.0, 1.0),
+            (1.0, 2.0),
+            (0.0, 2.0),
+        ];
+        let tris = triangulate_polygon(&points);
+        assert_eq!(tris.len(), points.len() - 2);
+        assert!(
+            (triangulated_area(&points, &tris) - polygon_area(&points)).abs() < 1e-5,
+            "triangulated area {} != polygon area {}",
+            triangulated_area(&points, &tris),
+            polygon_area(&points)
+        );
+    }
+
+    #[test]
+    fn triangulates_convex_n_gon() {
+        // Regular 13-gon - same vertex count as the Wall64 top mesh
+        // that surfaced the gap originally. Fan-triangulation should
+        // produce n - 2 = 11 triangles.
+        const N: usize = 13;
+        let points: Vec<(f32, f32)> = (0..N)
+            .map(|i| {
+                let t = (i as f32 / N as f32) * std::f32::consts::TAU;
+                (t.cos(), t.sin())
+            })
+            .collect();
+        let tris = triangulate_polygon(&points);
+        assert_eq!(tris.len(), N - 2);
+        assert!((triangulated_area(&points, &tris) - polygon_area(&points)).abs() < 1e-3);
+    }
+
+    #[test]
+    fn rejects_degenerate_polygons() {
+        assert!(triangulate_polygon(&[]).is_empty());
+        assert!(triangulate_polygon(&[(0.0, 0.0)]).is_empty());
+        assert!(triangulate_polygon(&[(0.0, 0.0), (1.0, 0.0)]).is_empty());
+    }
+
+    #[test]
+    fn lines_intersect_basic_cross() {
+        // Two segments that clearly cross.
+        assert!(lines_intersect(
+            (0.0, 0.0),
+            (1.0, 1.0),
+            (0.0, 1.0),
+            (1.0, 0.0)
+        ));
+        // Parallel non-overlapping.
+        assert!(!lines_intersect(
+            (0.0, 0.0),
+            (1.0, 0.0),
+            (0.0, 1.0),
+            (1.0, 1.0)
+        ));
+        // Note: vpinball's `FLinesIntersect` does NOT special-case
+        // shared endpoints - the caller (`AdvancePoint`) skips edges
+        // sharing a vertex with the diagonal before invoking this. We
+        // mirror that, so behavior on shared endpoints is unspecified.
     }
 }


### PR DESCRIPTION
Port `Rubber::GenerateMesh` / `Ramp::CreateWire`'s exact segment-count formula (with table detail-level and ramp-material-opacity inputs), and replace the textbook ear-clipping in `triangulate_polygon` with vpinball's `PolygonToTriangles` to close a concave wall-top gap.