### PR TITLE
fix(vpx): apply primitive position after scale + rotation in OBJ export

### DIFF
--- a/examples/export_table_obj.rs
+++ b/examples/export_table_obj.rs
@@ -1,16 +1,20 @@
-// Example showing how to export an entire VPX table as a Wavefront OBJ + MTL +
-// (optionally) an images folder.
+// Example showing how to export an entire VPX table as a Wavefront OBJ + MTL.
 //
-// Output layout, given `path/to/table.vpx`:
+// By default the result is tuned for use in DCC tools like Blender or
+// MeshLab: positions in metres, textures extracted to an `images/` folder,
+// duplicate `newmtl` blocks collapsed, top+side walls split into separate
+// face groups so each gets its own material/texture.
 //
 //   path/to/table_export/
 //   |-- table.obj
 //   |-- table.mtl
-//   `-- images/         (only with --with-textures)
+//   `-- images/
 //       `-- <texture-name>.<ext>
 //
-// The resulting .obj can be opened in any 3D viewer (Blender, MeshLab, ...).
-// Pass `--with-textures` if you want textures to show up in the viewer.
+// Pass `--vpinball-strict` to instead emit output that matches vpinball's
+// own `File -> Export -> OBJ Mesh` quirks (no textures, raw VPU positions,
+// duplicate `newmtl` blocks). Useful for diffing against a reference OBJ
+// produced by vpinball itself.
 
 use std::path::PathBuf;
 use vpin::filesystem::RealFileSystem;
@@ -23,16 +27,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 2 {
         eprintln!(
-            "Usage: cargo run --example export_table_obj <path_to_vpx> [units] [--with-textures]"
+            "Usage: cargo run --example export_table_obj <path_to_vpx> [units] [--vpinball-strict]"
         );
         eprintln!();
         eprintln!("Arguments:");
-        eprintln!("  path_to_vpx       Path to the .vpx file to export");
+        eprintln!("  path_to_vpx         Path to the .vpx file to export");
+        eprintln!("  units               Output unit: 'm' (default), 'mm', 'cm', or 'vpu'");
+        eprintln!("  --vpinball-strict   Match vpinball's own OBJ exporter (no textures, raw VPU,");
         eprintln!(
-            "  units             Output unit: 'vpu' (default, matches vpinball), 'mm', 'cm', or 'm'"
-        );
-        eprintln!(
-            "  --with-textures   Also extract images and reference them from the MTL (for DCC tools)"
+            "                      duplicate `newmtl` blocks). Overrides any units argument."
         );
         std::process::exit(1);
     }
@@ -43,17 +46,19 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::process::exit(1);
     }
 
-    let mut units = ExportUnits::Vpu;
-    let mut with_textures = false;
+    let mut units: Option<ExportUnits> = None;
+    let mut strict = false;
     for arg in args.iter().skip(2) {
         match arg.to_lowercase().as_str() {
-            "vpu" => units = ExportUnits::Vpu,
-            "mm" => units = ExportUnits::Mm,
-            "cm" => units = ExportUnits::Cm,
-            "m" => units = ExportUnits::M,
-            "--with-textures" => with_textures = true,
+            "vpu" => units = Some(ExportUnits::Vpu),
+            "mm" => units = Some(ExportUnits::Mm),
+            "cm" => units = Some(ExportUnits::Cm),
+            "m" => units = Some(ExportUnits::M),
+            "--vpinball-strict" => strict = true,
             other => {
-                eprintln!("Error: unknown argument '{other}'. Use vpu/mm/cm/m or --with-textures.");
+                eprintln!(
+                    "Error: unknown argument '{other}'. Use vpu/mm/cm/m or --vpinball-strict."
+                );
                 std::process::exit(1);
             }
         }
@@ -75,16 +80,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Reading VPX file: {}", vpx_path.display());
     let vpx = vpx::read(&vpx_path)?;
 
-    println!(
-        "Exporting to {} (units: {units:?}, textures: {})",
-        obj_path.display(),
-        if with_textures { "yes" } else { "no" },
-    );
-    let options = ObjExportOptions {
-        units,
-        extract_textures: with_textures,
-        ..ObjExportOptions::default()
+    let mut options = if strict {
+        ObjExportOptions::vpinball_strict()
+    } else {
+        ObjExportOptions::default()
     };
+    if let Some(u) = units {
+        options.units = u;
+    }
+
+    println!(
+        "Exporting to {} (units: {:?}, mode: {})",
+        obj_path.display(),
+        options.units,
+        if strict { "vpinball-strict" } else { "default" },
+    );
     export_obj(&vpx, &obj_path, &RealFileSystem, &options)?;
 
     let obj_size = std::fs::metadata(&obj_path)?.len();
@@ -94,7 +104,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Done.");
     println!("  obj:    {} ({} bytes)", obj_path.display(), obj_size);
     println!("  mtl:    {} ({} bytes)", mtl_path.display(), mtl_size);
-    if with_textures {
+    if options.extract_textures {
         println!("  images: {}", out_dir.join("images").display());
     }
 

--- a/examples/export_table_obj.rs
+++ b/examples/export_table_obj.rs
@@ -1,15 +1,16 @@
 // Example showing how to export an entire VPX table as a Wavefront OBJ + MTL +
-// images folder.
+// (optionally) an images folder.
 //
 // Output layout, given `path/to/table.vpx`:
 //
 //   path/to/table_export/
-//   ├── table.obj
-//   ├── table.mtl
-//   └── images/
-//       └── <texture-name>.<ext>
+//   |-- table.obj
+//   |-- table.mtl
+//   `-- images/         (only with --with-textures)
+//       `-- <texture-name>.<ext>
 //
 // The resulting .obj can be opened in any 3D viewer (Blender, MeshLab, ...).
+// Pass `--with-textures` if you want textures to show up in the viewer.
 
 use std::path::PathBuf;
 use vpin::filesystem::RealFileSystem;
@@ -21,12 +22,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let args: Vec<String> = std::env::args().collect();
     if args.len() < 2 {
-        eprintln!("Usage: cargo run --example export_table_obj <path_to_vpx> [units]");
+        eprintln!(
+            "Usage: cargo run --example export_table_obj <path_to_vpx> [units] [--with-textures]"
+        );
         eprintln!();
         eprintln!("Arguments:");
-        eprintln!("  path_to_vpx  Path to the .vpx file to export");
+        eprintln!("  path_to_vpx       Path to the .vpx file to export");
         eprintln!(
-            "  units        Output unit: 'vpu' (default, matches vpinball), 'mm', 'cm', or 'm'"
+            "  units             Output unit: 'vpu' (default, matches vpinball), 'mm', 'cm', or 'm'"
+        );
+        eprintln!(
+            "  --with-textures   Also extract images and reference them from the MTL (for DCC tools)"
         );
         std::process::exit(1);
     }
@@ -37,19 +43,21 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         std::process::exit(1);
     }
 
-    let units = match args.get(2).map(|s| s.to_lowercase()) {
-        None => ExportUnits::Vpu,
-        Some(s) => match s.as_str() {
-            "vpu" => ExportUnits::Vpu,
-            "mm" => ExportUnits::Mm,
-            "cm" => ExportUnits::Cm,
-            "m" => ExportUnits::M,
+    let mut units = ExportUnits::Vpu;
+    let mut with_textures = false;
+    for arg in args.iter().skip(2) {
+        match arg.to_lowercase().as_str() {
+            "vpu" => units = ExportUnits::Vpu,
+            "mm" => units = ExportUnits::Mm,
+            "cm" => units = ExportUnits::Cm,
+            "m" => units = ExportUnits::M,
+            "--with-textures" => with_textures = true,
             other => {
-                eprintln!("Error: unknown units '{other}'. Use vpu, mm, cm, or m.");
+                eprintln!("Error: unknown argument '{other}'. Use vpu/mm/cm/m or --with-textures.");
                 std::process::exit(1);
             }
-        },
-    };
+        }
+    }
 
     let stem = vpx_path
         .file_stem()
@@ -67,9 +75,14 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Reading VPX file: {}", vpx_path.display());
     let vpx = vpx::read(&vpx_path)?;
 
-    println!("Exporting to {} (units: {units:?})", obj_path.display());
+    println!(
+        "Exporting to {} (units: {units:?}, textures: {})",
+        obj_path.display(),
+        if with_textures { "yes" } else { "no" },
+    );
     let options = ObjExportOptions {
         units,
+        extract_textures: with_textures,
         ..ObjExportOptions::default()
     };
     export_obj(&vpx, &obj_path, &RealFileSystem, &options)?;
@@ -81,7 +94,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("Done.");
     println!("  obj:    {} ({} bytes)", obj_path.display(), obj_size);
     println!("  mtl:    {} ({} bytes)", mtl_path.display(), mtl_size);
-    println!("  images: {}", out_dir.join("images").display());
+    if with_textures {
+        println!("  images: {}", out_dir.join("images").display());
+    }
 
     Ok(())
 }

--- a/src/vpx/export/gltf_export.rs
+++ b/src/vpx/export/gltf_export.rs
@@ -195,6 +195,11 @@ struct NamedMesh {
     /// is applied via the glTF node's "translation" property.
     /// Coordinates: VPX X → glTF X, VPX Z → glTF Y, VPX Y → glTF Z
     translation: Option<Vec3>,
+    /// Optional node scale, applied via the glTF node's "scale" property.
+    /// Lets a mesh that was generated unscaled (e.g. gate wires, which
+    /// vpinball's OBJ exporter never scales) still appear at runtime size
+    /// in DCC tools without forking the mesh-generation path.
+    scale: Option<Vec3>,
     /// Whether the node is visible.
     /// When false, the node will be exported with the KHR_node_visibility extension
     /// set to `visible: false`. Defaults to true.
@@ -250,6 +255,7 @@ impl Default for NamedMesh {
             is_ball: false,
             roughness_texture_name: None,
             translation: None,
+            scale: None,
             visible: true,
             group_name: None,
         }
@@ -1337,7 +1343,15 @@ fn collect_meshes(vpx: &VPX, options: &GltfExportOptions) -> (Vec<NamedMesh>, Ve
                         });
                     }
 
-                    // Add wire/plate mesh
+                    // Add wire/plate mesh.
+                    //
+                    // The wire mesh is left unscaled by `generate_wire_mesh`
+                    // to match vpinball's OBJ exporter (`Gate::GenerateWireMesh`,
+                    // gate.cpp:529). For runtime appearance vpinball multiplies
+                    // by `gate.length` (see `RenderDynamic`); we fold the same
+                    // scale into the glTF node so the same mesh data serves
+                    // both exporters.
+                    let length = gate.length;
                     let (wire_vertices, wire_indices) = gate_meshes.wire;
                     meshes.push(NamedMesh {
                         name: format!("{}Wire", gate.name),
@@ -1346,6 +1360,7 @@ fn collect_meshes(vpx: &VPX, options: &GltfExportOptions) -> (Vec<NamedMesh>, Ve
                         material_name,
                         layer_name: gate_layer_name.clone(),
                         translation,
+                        scale: Some(Vec3::new(length, length, length)),
                         visible: gate.is_visible,
                         group_name: Some(gate.name.clone()),
                         ..Default::default()
@@ -2520,6 +2535,9 @@ fn build_combined_gltf_payload(
         // Add translation if set (for primitives using node transforms)
         if let Some(translation) = mesh.translation {
             node["translation"] = json!([translation.x, translation.y, translation.z]);
+        }
+        if let Some(scale) = mesh.scale {
+            node["scale"] = json!([scale.x, scale.y, scale.z]);
         }
 
         // Add KHR_node_visibility extension for invisible nodes

--- a/src/vpx/export/obj_export.rs
+++ b/src/vpx/export/obj_export.rs
@@ -61,49 +61,74 @@ use std::io;
 use std::path::{Path, PathBuf};
 use wavefront_obj_io::{IoMtlWriter, IoObjWriter, MapKind, MtlWriter, ObjWriter, SmoothingGroup};
 
-/// Options controlling OBJ export behaviour. Defaults match VPinball's
-/// own `File -> Export -> OBJ Mesh` byte for byte.
-#[derive(Debug, Clone, Default)]
+/// Options controlling OBJ export behaviour.
+///
+/// The defaults are tuned for "useful in DCC tools" (Blender, MeshLab):
+/// textures are extracted and referenced, duplicate `newmtl` blocks are
+/// collapsed, and positions are emitted in metres. To produce output
+/// that matches vpinball's `File -> Export -> OBJ Mesh` quirks
+/// (duplicate blocks, no texture maps, raw VPU positions, combined
+/// top+side wall blocks), set every field back to the vpinball-strict
+/// values - see [`Self::vpinball_strict`].
+#[derive(Debug, Clone)]
 pub struct ObjExportOptions {
     /// Deduplicate `newmtl` blocks in the MTL file by `(material,
     /// texture)` pair.
     ///
-    /// - **`false` (default)**: emit one `newmtl` block per `usemtl`,
-    ///   matching VPinball's output exactly. The MTL contains one entry
-    ///   per item-block, which can mean many duplicates for tables that
+    /// - **`true` (default)**: only the first occurrence of each
+    ///   `(material, texture)` pair gets a `newmtl` block. Produces a
+    ///   smaller MTL with no duplicate blocks.
+    /// - **`false`**: emit one `newmtl` block per `usemtl`, matching
+    ///   VPinball's output exactly. The MTL contains one entry per
+    ///   item-block, which can mean many duplicates for tables that
     ///   share materials across items.
-    /// - **`true`**: only the first occurrence of each `(material,
-    ///   texture)` pair gets a `newmtl` block. The `usemtl` references
-    ///   in the OBJ still resolve correctly (they all point at the same
-    ///   sanitized name). Produces a smaller MTL but diverges from
-    ///   VPinball's reference output.
     pub dedup_mtl_blocks: bool,
 
     /// Whether to extract referenced texture images to an `images/`
     /// sibling folder and reference them via `map_Kd`/`map_Ka` lines
     /// in the MTL.
     ///
-    /// - **`false` (default)**: vpinball-faithful. No images are
-    ///   written and no `map_*` lines are emitted, matching what
-    ///   `File -> Export -> OBJ Mesh` produces (vpinball passes an
-    ///   empty texelFilename to `WriteMaterial` for everything except
-    ///   wall tops with an image, and for that case the path it emits
-    ///   is the original on-disk source path - which we cannot
-    ///   replicate from a packaged VPX).
-    /// - **`true`**: extract every referenced texture into the
-    ///   `images/` folder and reference each one from its `newmtl`
-    ///   block. Useful when loading the OBJ into Blender / MeshLab so
-    ///   textures show up. Note: when multiple items reuse the same
-    ///   material name with different textures, `usemtl` references
-    ///   currently resolve to whichever block parses last - a separate
-    ///   dedup pass is needed for fully-correct DCC output. Combine
-    ///   with [`Self::dedup_mtl_blocks`] as a partial workaround.
+    /// - **`true` (default)**: extract every referenced texture into
+    ///   the `images/` folder and reference each one from its
+    ///   `newmtl` block. Items reusing a material name with different
+    ///   textures get unique `newmtl <material>__<texture>` names so
+    ///   `usemtl` references resolve correctly. Top+side walls are
+    ///   split into separate `<name>Side` + `<name>Top` blocks so
+    ///   each face group gets its own material and texture.
+    /// - **`false`**: vpinball-faithful. No images are written and no
+    ///   `map_*` lines are emitted, matching what
+    ///   `File -> Export -> OBJ Mesh` produces. Top+side walls stay
+    ///   as a single combined block with the top material only (also
+    ///   matching vpinball).
     pub extract_textures: bool,
 
-    /// Output unit for vertex positions. Default is [`ExportUnits::Vpu`]
-    /// (no scaling) for vpinball parity. Use [`ExportUnits::Mm`] or
-    /// [`ExportUnits::M`] when loading the result into a DCC tool.
+    /// Output unit for vertex positions. Default is [`ExportUnits::M`]
+    /// so the OBJ imports at sensible scale into DCC tools. Use
+    /// [`ExportUnits::Vpu`] for vpinball parity.
     pub units: ExportUnits,
+}
+
+impl Default for ObjExportOptions {
+    fn default() -> Self {
+        Self {
+            dedup_mtl_blocks: true,
+            extract_textures: true,
+            units: ExportUnits::M,
+        }
+    }
+}
+
+impl ObjExportOptions {
+    /// Options that produce output matching vpinball's
+    /// `File -> Export -> OBJ Mesh` as closely as possible. Useful for
+    /// diffing against vpinball-generated reference files.
+    pub fn vpinball_strict() -> Self {
+        Self {
+            dedup_mtl_blocks: false,
+            extract_textures: false,
+            units: ExportUnits::Vpu,
+        }
+    }
 }
 
 /// Export the entire VPX table as a Wavefront OBJ + companion MTL + images
@@ -574,6 +599,15 @@ fn write_wall<O: ObjWriter<f32>, M: MtlWriter<f32>>(
         }
         (false, true, _, Some((vertices, indices))) => {
             let material_name = wall.side_material.clone();
+            // VPinball's side-only branch (surface.cpp:734) drops the
+            // image like the top+side branch. Pipe `side_image`
+            // through so DCC tools see the texture in textured mode;
+            // `emit_mtl_block` ignores it in vpinball-strict mode.
+            let texture_name = if wall.side_image.is_empty() {
+                None
+            } else {
+                Some(wall.side_image.as_str())
+            };
             write_block(
                 obj,
                 mtl,
@@ -585,37 +619,98 @@ fn write_wall<O: ObjWriter<f32>, M: MtlWriter<f32>>(
                     indices: &indices,
                     translation: Vec3::new(0.0, 0.0, 0.0),
                     material_name: Some(&material_name),
-                    texture_name: None,
+                    texture_name,
                     smoothing: false,
                 },
             )?;
         }
         (true, true, Some((top_v, top_i)), Some((side_v, side_i))) => {
-            let side_count = side_v.len() as i64;
-            let mut combined_v = side_v;
-            combined_v.extend(top_v);
-            let mut combined_i = side_i;
-            combined_i.extend(top_i.into_iter().map(|f| VpxFace {
-                i0: f.i0 + side_count,
-                i1: f.i1 + side_count,
-                i2: f.i2 + side_count,
-            }));
-            let material_name = wall.top_material.clone();
-            write_block(
-                obj,
-                mtl,
-                state,
-                fs,
-                Block {
-                    name: &wall.name,
-                    vertices: &combined_v,
-                    indices: &combined_i,
-                    translation: Vec3::new(0.0, 0.0, 0.0),
-                    material_name: Some(&material_name),
-                    texture_name: None,
-                    smoothing: true,
-                },
-            )?;
+            // Two output strategies, picked at runtime:
+            //
+            // - `extract_textures = false` (vpinball-strict): emit a
+            //   single combined `o <name>` block with the top material
+            //   only, matching `Surface::ExportMesh` (surface.cpp:709-735)
+            //   byte for byte. Sides and top share one `usemtl`; the
+            //   wall's image is dropped because OBJ allows only one
+            //   texture per face group and vpinball doesn't bother
+            //   splitting.
+            // - `extract_textures = true` (DCC-friendly): split into
+            //   `o <name>Side` and `o <name>Top` so each face group
+            //   carries its own material + image. This is the only
+            //   way to get correct top+side textures into Blender;
+            //   otherwise the side faces would render with the top's
+            //   texture stretched across their UVs.
+            if state.extract_textures {
+                let side_material = wall.side_material.clone();
+                let side_texture = if wall.side_image.is_empty() {
+                    None
+                } else {
+                    Some(wall.side_image.as_str())
+                };
+                write_block(
+                    obj,
+                    mtl,
+                    state,
+                    fs,
+                    Block {
+                        name: &format!("{}Side", wall.name),
+                        vertices: &side_v,
+                        indices: &side_i,
+                        translation: Vec3::new(0.0, 0.0, 0.0),
+                        material_name: Some(&side_material),
+                        texture_name: side_texture,
+                        smoothing: true,
+                    },
+                )?;
+
+                let top_material = wall.top_material.clone();
+                let top_texture = if wall.image.is_empty() {
+                    None
+                } else {
+                    Some(wall.image.as_str())
+                };
+                write_block(
+                    obj,
+                    mtl,
+                    state,
+                    fs,
+                    Block {
+                        name: &format!("{}Top", wall.name),
+                        vertices: &top_v,
+                        indices: &top_i,
+                        translation: Vec3::new(0.0, 0.0, 0.0),
+                        material_name: Some(&top_material),
+                        texture_name: top_texture,
+                        smoothing: true,
+                    },
+                )?;
+            } else {
+                let side_count = side_v.len() as i64;
+                let mut combined_v = side_v;
+                combined_v.extend(top_v);
+                let mut combined_i = side_i;
+                combined_i.extend(top_i.into_iter().map(|f| VpxFace {
+                    i0: f.i0 + side_count,
+                    i1: f.i1 + side_count,
+                    i2: f.i2 + side_count,
+                }));
+                let material_name = wall.top_material.clone();
+                write_block(
+                    obj,
+                    mtl,
+                    state,
+                    fs,
+                    Block {
+                        name: &wall.name,
+                        vertices: &combined_v,
+                        indices: &combined_i,
+                        translation: Vec3::new(0.0, 0.0, 0.0),
+                        material_name: Some(&material_name),
+                        texture_name: None,
+                        smoothing: true,
+                    },
+                )?;
+            }
         }
         _ => {}
     }
@@ -1459,13 +1554,28 @@ mod tests {
     }
 
     #[test]
-    fn default_options_emit_one_newmtl_per_usemtl() {
-        // VPinball-faithful default: each `usemtl` gets a `newmtl`.
-        let (obj, mtl) = export_to_memory(&ObjExportOptions::default());
+    fn vpinball_strict_emits_one_newmtl_per_usemtl() {
+        // VPinball-strict mode: each `usemtl` gets its own `newmtl`,
+        // including duplicates - matches `Surface::ExportMesh`.
+        let (obj, mtl) = export_to_memory(&ObjExportOptions::vpinball_strict());
         let usemtl = obj.matches("usemtl ").count();
         let newmtl = mtl.matches("newmtl ").count();
         assert!(usemtl > 0);
         assert_eq!(usemtl, newmtl);
+    }
+
+    #[test]
+    fn default_options_dedup_newmtl_blocks() {
+        // The DCC-friendly default collapses duplicate `(material,
+        // texture)` pairs into a single `newmtl` block.
+        let (obj, mtl) = export_to_memory(&ObjExportOptions::default());
+        let usemtl = obj.matches("usemtl ").count();
+        let newmtl = mtl.matches("newmtl ").count();
+        assert!(usemtl >= 1);
+        assert!(
+            newmtl <= usemtl,
+            "newmtl ({newmtl}) should not exceed usemtl ({usemtl}) when deduped",
+        );
     }
 
     /// Find the vertex with the largest |x| in an OBJ string, returning

--- a/src/vpx/export/obj_export.rs
+++ b/src/vpx/export/obj_export.rs
@@ -1176,12 +1176,22 @@ fn write_block<O: ObjWriter<f32>, M: MtlWriter<f32>>(
 /// VPinball does the same in `WriteMaterial` for both the MTL block and
 /// the `usemtl`).
 ///
-/// By default vpinball-style: emits one `newmtl` block per call, with
-/// duplicates. When `state.dedup_mtl_blocks` is set, only the first
-/// occurrence of each `(material, texture)` pair is written; subsequent
-/// calls still resolve the on-disk image (so it gets extracted) but
-/// skip the MTL block. The `usemtl` reference in the OBJ remains the
-/// same sanitized name and resolves to the first-emitted block.
+/// Behaviour depends on the active options:
+///
+/// - `extract_textures = false` (vpinball-faithful):
+///   the returned name is the bare sanitised material name. With
+///   `dedup_mtl_blocks = false` the same `newmtl <name>` block is
+///   re-emitted per call, matching vpinball byte-for-byte. With
+///   `dedup_mtl_blocks = true` we keep just the first occurrence.
+/// - `extract_textures = true`:
+///   when the item carries a texture, we emit a unique
+///   `newmtl <material>__<image>` block so DCC tools resolve every
+///   `usemtl` to the right `map_Kd` line. Items with the same
+///   material name but different textures no longer step on each
+///   other. The texture file is extracted into `images/` on first
+///   use; repeat `(material, texture)` pairs reuse the same `newmtl`
+///   block (effectively forcing dedup for textured items so we
+///   don't emit identical blocks twice).
 fn emit_mtl_block<M: MtlWriter<f32>>(
     mtl: &mut M,
     state: &mut WriterState,
@@ -1189,8 +1199,6 @@ fn emit_mtl_block<M: MtlWriter<f32>>(
     material_name: &str,
     texture_name: Option<&str>,
 ) -> io::Result<String> {
-    let mtl_name = sanitize_material_name(material_name);
-
     // Resolve the on-disk image filename and ensure the file is written.
     // Skipped entirely in vpinball-faithful mode (no `map_*` lines, no
     // `images/` folder) - vpinball's exporter doesn't extract textures.
@@ -1204,7 +1212,30 @@ fn emit_mtl_block<M: MtlWriter<f32>>(
         None
     };
 
-    if state.dedup_mtl_blocks {
+    // Construct the `newmtl`/`usemtl` name. In vpinball-faithful mode
+    // it's just the sanitised material name. In texture-emitting mode
+    // we mangle in the image name so each `(material, texture)` pair
+    // gets its own block, which avoids the "last newmtl wins" trap
+    // when multiple items reuse a material name.
+    let mtl_name = if state.extract_textures
+        && let Some(tex) = texture_name
+        && !tex.is_empty()
+    {
+        format!(
+            "{}__{}",
+            sanitize_material_name(material_name),
+            sanitize_filename(tex),
+        )
+    } else {
+        sanitize_material_name(material_name)
+    };
+
+    // With unique-per-pair names, the same pair would otherwise emit
+    // identical `newmtl` blocks every time the same item-style
+    // recurs. Force dedup whenever we extract textures so we only
+    // write the block on first sight.
+    let force_dedup = state.extract_textures && map_path.is_some();
+    if state.dedup_mtl_blocks || force_dedup {
         let key = (
             material_name.to_string(),
             texture_name.unwrap_or("").to_string(),

--- a/src/vpx/export/obj_export.rs
+++ b/src/vpx/export/obj_export.rs
@@ -425,9 +425,18 @@ fn write_primitive<O: ObjWriter<f32>, M: MtlWriter<f32>>(
     )
 }
 
-/// Compose the full vpx-space world matrix for a primitive, including the
-/// position translation that VPinball folds into `m_fullMatrix` for
-/// `Primitive::ExportMesh`.
+/// Compose the full vpx-space world matrix for a primitive, mirroring
+/// VPinball's `Primitive::RecalculateMatrices`:
+///
+/// ```text
+/// RT       = Translate(tra) * RotZ(rot[2]) * RotY(rot[1]) * RotX(rot[0])
+///                           * RotZ(rot[8]) * RotY(rot[7]) * RotX(rot[6])
+/// fullMat  = Scale(size) * RT * Translate(pos)
+/// ```
+///
+/// Order matters: position is applied *after* scale + rotation so it
+/// doesn't get rotated/scaled along with the mesh. Got bitten by this -
+/// see the regression test in this file.
 fn primitive_world_matrix(primitive: &Primitive) -> Matrix3D {
     let pos = &primitive.position;
     let size = &primitive.size;
@@ -441,7 +450,7 @@ fn primitive_world_matrix(primitive: &Primitive) -> Matrix3D {
         * Matrix3D::rotate_y(rot[7].to_radians())
         * Matrix3D::rotate_x(rot[6].to_radians());
 
-    Matrix3D::translate(pos.x, pos.y, pos.z) * Matrix3D::scale(size.x, size.y, size.z) * rt
+    Matrix3D::scale(size.x, size.y, size.z) * rt * Matrix3D::translate(pos.x, pos.y, pos.z)
 }
 
 fn write_wall<O: ObjWriter<f32>, M: MtlWriter<f32>>(
@@ -1304,6 +1313,46 @@ mod tests {
         let mtl =
             String::from_utf8(fs.read_file(&obj_path.with_extension("mtl")).unwrap()).unwrap();
         (obj, mtl)
+    }
+
+    #[test]
+    fn primitive_world_matrix_does_not_scale_position() {
+        // Regression: the previous order `Translate(pos) * Scale * RT`
+        // applied scale/rotation to the position itself. With size != 1
+        // and a non-zero rotation, primitives ended up far from where
+        // vpinball places them. Verify the world matrix matches the
+        // vpinball convention `Scale * RT * Translate(pos)`.
+        //
+        // Setup:
+        //   - local vertex at (1, 0, 0)
+        //   - size  = (2, 2, 2)         (would be doubled if scale leaked into pos)
+        //   - rot[0] = 90 deg around X  (would rotate pos if order is wrong)
+        //   - pos = (10, 20, 30)
+        //
+        // Expected (vpinball): scale -> rotate -> translate(pos)
+        //   v_local = (1, 0, 0)
+        //   after scale(2): (2, 0, 0)
+        //   after RotX(90): (2, 0, 0)   (X axis is invariant)
+        //   after Translate(pos): (12, 20, 30)
+        use crate::vpx::gameitem::vertex3d::Vertex3D as ItemVertex3D;
+        let primitive = Primitive {
+            position: ItemVertex3D::new(10.0, 20.0, 30.0),
+            size: ItemVertex3D::new(2.0, 2.0, 2.0),
+            rot_and_tra: [90.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            ..Primitive::default()
+        };
+
+        let m = primitive_world_matrix(&primitive);
+        let out = m.transform_vertex(Vertex3D::new(1.0, 0.0, 0.0));
+        assert!(
+            (out.x - 12.0).abs() < 1e-4
+                && (out.y - 20.0).abs() < 1e-4
+                && (out.z - 30.0).abs() < 1e-4,
+            "expected (12, 20, 30), got ({}, {}, {})",
+            out.x,
+            out.y,
+            out.z,
+        );
     }
 
     #[test]

--- a/src/vpx/export/obj_export.rs
+++ b/src/vpx/export/obj_export.rs
@@ -1,10 +1,8 @@
 //! Wavefront OBJ export of an entire VPX table.
 //!
 //! Mirrors VPinball's `File -> Export -> OBJ Mesh`: produces a single `.obj`
-//! file with one `o` block per item (playfield + every visible game item),
-//! a single `.mtl` file with one `newmtl` block per unique
-//! `(material, texture)` pair encountered, and an `images/` sibling folder
-//! containing the texture files referenced from the `.mtl`.
+//! file with one `o` block per item (playfield + every visible game item)
+//! and a single `.mtl` material library.
 //!
 //! Output layout, given `path/to/<stem>.obj`:
 //!
@@ -12,9 +10,14 @@
 //! path/to/
 //! +-- <stem>.obj
 //! +-- <stem>.mtl
-//! +-- images/
+//! +-- images/        (only when `ObjExportOptions::extract_textures` is set)
 //!     +-- <texture-name>.<ext>
 //! ```
+//!
+//! By default no textures are written. Set
+//! [`ObjExportOptions::extract_textures`] to populate `images/` and emit
+//! `map_Kd`/`map_Ka` lines so the result loads with textures in DCC
+//! tools like Blender.
 //!
 //! Coordinate convention matches VPinball's `ObjLoader`:
 //!
@@ -75,6 +78,27 @@ pub struct ObjExportOptions {
     ///   sanitized name). Produces a smaller MTL but diverges from
     ///   VPinball's reference output.
     pub dedup_mtl_blocks: bool,
+
+    /// Whether to extract referenced texture images to an `images/`
+    /// sibling folder and reference them via `map_Kd`/`map_Ka` lines
+    /// in the MTL.
+    ///
+    /// - **`false` (default)**: vpinball-faithful. No images are
+    ///   written and no `map_*` lines are emitted, matching what
+    ///   `File -> Export -> OBJ Mesh` produces (vpinball passes an
+    ///   empty texelFilename to `WriteMaterial` for everything except
+    ///   wall tops with an image, and for that case the path it emits
+    ///   is the original on-disk source path - which we cannot
+    ///   replicate from a packaged VPX).
+    /// - **`true`**: extract every referenced texture into the
+    ///   `images/` folder and reference each one from its `newmtl`
+    ///   block. Useful when loading the OBJ into Blender / MeshLab so
+    ///   textures show up. Note: when multiple items reuse the same
+    ///   material name with different textures, `usemtl` references
+    ///   currently resolve to whichever block parses last - a separate
+    ///   dedup pass is needed for fully-correct DCC output. Combine
+    ///   with [`Self::dedup_mtl_blocks`] as a partial workaround.
+    pub extract_textures: bool,
 
     /// Output unit for vertex positions. Default is [`ExportUnits::Vpu`]
     /// (no scaling) for vpinball parity. Use [`ExportUnits::Mm`] or
@@ -205,6 +229,9 @@ struct WriterState<'a> {
     /// Whether to dedup `newmtl` blocks in the MTL file. See
     /// [`ObjExportOptions::dedup_mtl_blocks`].
     dedup_mtl_blocks: bool,
+    /// Whether to extract images and emit `map_*` lines. See
+    /// [`ObjExportOptions::extract_textures`].
+    extract_textures: bool,
     /// `(material_name, texture_name)` pairs already emitted as a
     /// `newmtl` block. Only consulted when `dedup_mtl_blocks` is true.
     seen_mtl_pairs: HashSet<(String, String)>,
@@ -231,6 +258,7 @@ impl<'a> WriterState<'a> {
             image_dedup_counter: 0,
             images_written: HashSet::new(),
             dedup_mtl_blocks: options.dedup_mtl_blocks,
+            extract_textures: options.extract_textures,
             seen_mtl_pairs: HashSet::new(),
             position_scale: options.units.scale(),
         }
@@ -1164,10 +1192,14 @@ fn emit_mtl_block<M: MtlWriter<f32>>(
     let mtl_name = sanitize_material_name(material_name);
 
     // Resolve the on-disk image filename and ensure the file is written.
-    // We do this whether or not we're about to skip the MTL block, so
-    // the `images/` folder stays complete in dedup mode too.
-    let map_path = if let Some(name) = texture_name {
-        ensure_image_written(state, fs, name)?
+    // Skipped entirely in vpinball-faithful mode (no `map_*` lines, no
+    // `images/` folder) - vpinball's exporter doesn't extract textures.
+    let map_path = if state.extract_textures {
+        if let Some(name) = texture_name {
+            ensure_image_written(state, fs, name)?
+        } else {
+            None
+        }
     } else {
         None
     };

--- a/src/vpx/export/obj_export.rs
+++ b/src/vpx/export/obj_export.rs
@@ -32,11 +32,12 @@
 use crate::filesystem::FileSystem;
 use crate::vpx::TableDimensions;
 use crate::vpx::VPX;
+use crate::vpx::color::Color;
 use crate::vpx::expanded::util::sanitize_filename;
 use crate::vpx::gameitem::GameItemEnum;
 use crate::vpx::gameitem::primitive::{Primitive, VertexWrapper};
 use crate::vpx::image::ImageData;
-use crate::vpx::material::{Material, MaterialType};
+use crate::vpx::material::MaterialType;
 use crate::vpx::math::{Matrix3D, Vec3, Vertex3D};
 use crate::vpx::mesh::bumpers::build_bumper_meshes;
 use crate::vpx::mesh::flippers::build_flipper_meshes_unchecked;
@@ -163,6 +164,18 @@ pub fn export_obj(
     Ok(())
 }
 
+/// Material fields consumed by the MTL writer. Sourced from either the
+/// new `MATR` chunk (`Material`) or the legacy `MATE` chunk
+/// (`SaveMaterial`), so the OBJ exporter doesn't have to care which
+/// version of vpinball saved the table.
+struct MaterialView {
+    base_color: Color,
+    glossy_color: Color,
+    opacity: f32,
+    opacity_active: bool,
+    is_metal: bool,
+}
+
 // ---------------------------------------------------------------------------
 // State threaded through the walk.
 // ---------------------------------------------------------------------------
@@ -223,12 +236,39 @@ impl<'a> WriterState<'a> {
         }
     }
 
-    fn material_by_name(&self, name: &str) -> Option<&Material> {
+    /// Look up a material by name, transparently falling back from the
+    /// new (10.8+) `MATR` chunk to the legacy `MATE` chunk used by older
+    /// tables. Without the legacy fallback, pre-10.8 VPX files appear to
+    /// have no materials at all and every `Kd`/`Ks` ends up at the
+    /// "material missing" defaults (white / black) instead of the
+    /// authored colours.
+    fn material_view_by_name(&self, name: &str) -> Option<MaterialView> {
         if name.is_empty() {
             return None;
         }
-        if let Some(ref mats) = self.vpx.gamedata.materials {
-            return mats.iter().find(|m| m.name.eq_ignore_ascii_case(name));
+        if let Some(ref mats) = self.vpx.gamedata.materials
+            && let Some(m) = mats.iter().find(|m| m.name.eq_ignore_ascii_case(name))
+        {
+            return Some(MaterialView {
+                base_color: m.base_color,
+                glossy_color: m.glossy_color,
+                opacity: m.opacity,
+                opacity_active: m.opacity_active,
+                is_metal: m.type_ == MaterialType::Metal,
+            });
+        }
+        for m in &self.vpx.gamedata.materials_old {
+            if m.name.eq_ignore_ascii_case(name) {
+                return Some(MaterialView {
+                    base_color: m.base_color,
+                    glossy_color: m.glossy_color,
+                    opacity: m.opacity,
+                    // Bit 0 of `opacity_active_edge_alpha` is the
+                    // active flag, the upper 7 bits are the edge alpha.
+                    opacity_active: (m.opacity_active_edge_alpha & 1) != 0,
+                    is_metal: m.is_metal,
+                });
+            }
         }
         None
     }
@@ -569,7 +609,7 @@ fn write_ramp<O: ObjWriter<f32>, M: MtlWriter<f32>>(
     // Missing/empty material falls through to opaque (vpinball's dummy
     // material defaults `m_bOpacityActive = false`).
     let material_opacity_active = state
-        .material_by_name(&ramp.material)
+        .material_view_by_name(&ramp.material)
         .is_some_and(|m| m.opacity_active);
     let Some((vertices, indices)) = build_ramp_mesh(
         ramp,
@@ -1159,13 +1199,13 @@ fn write_mtl_block<M: MtlWriter<f32>>(
     material_name: &str,
     image_relative_path: Option<&str>,
 ) -> io::Result<()> {
-    let material = state.material_by_name(material_name);
+    let material = state.material_view_by_name(material_name);
 
     // Defaults match VPinball's WriteMaterial when no Material is found.
     let (kd, ks, opacity) = match material {
         Some(m) => (
-            color_to_kd(m),
-            color_to_ks(m),
+            color_to_kd(&m),
+            color_to_ks(&m),
             if m.opacity_active { m.opacity } else { 1.0 },
         ),
         None => ([1.0, 1.0, 1.0], [0.0, 0.0, 0.0], 1.0),
@@ -1186,7 +1226,7 @@ fn write_mtl_block<M: MtlWriter<f32>>(
     Ok(())
 }
 
-fn color_to_kd(m: &Material) -> [f32; 3] {
+fn color_to_kd(m: &MaterialView) -> [f32; 3] {
     [
         m.base_color.r as f32 / 255.0,
         m.base_color.g as f32 / 255.0,
@@ -1194,8 +1234,8 @@ fn color_to_kd(m: &Material) -> [f32; 3] {
     ]
 }
 
-fn color_to_ks(m: &Material) -> [f32; 3] {
-    if m.type_ == MaterialType::Metal {
+fn color_to_ks(m: &MaterialView) -> [f32; 3] {
+    if m.is_metal {
         // Match VPinball's `m_cGlossy` for metals (uses base color).
         color_to_kd(m)
     } else {

--- a/src/vpx/mesh/gates/mod.rs
+++ b/src/vpx/mesh/gates/mod.rs
@@ -108,33 +108,23 @@ fn generate_bracket_mesh(gate: &Gate) -> (Vec<VertexWrapper>, Vec<VpxFace>) {
 
 /// Generate gate wire/plate mesh.
 ///
-/// Two valid VPinball reference points:
+/// Mirrors VPinball's `Gate::GenerateWireMesh` (gate.cpp:527-531):
+/// applies `RotateZ` only - **no** `Scale(length)` and no translation.
+/// VPinball's runtime renderer (`RenderDynamic`, gate.cpp:417-418)
+/// adds the length scale on top, but its OBJ exporter does not. By
+/// always producing the unscaled form we match the exporter byte-for
+/// -byte; consumers that want the runtime appearance (e.g. glTF)
+/// should apply `gate.length` as a node-level scale.
 ///
-/// - **`Gate::RenderDynamic`** (gate.cpp:417-418) - the in-game renderer.
-///   Applies `RotateZ * Scale(length) * Translate(...)`, so the wire is
-///   scaled by `m_d.m_length`. This is what we want for visual export
-///   targets like glTF.
-/// - **`Gate::GenerateWireMesh`** (gate.cpp:527-531) - the OBJ export
-///   path. Applies only `RotateZ * Translate(...)`, with NO length
-///   scaling (a vpinball quirk: bracket scales, wire doesn't).
-///
-/// `scale_by_length = true` matches the runtime, `false` matches the
-/// vpinball OBJ exporter byte-for-byte.
-///
-/// Translation is NOT applied here - use gate.center and height for the
-/// caller's node/object transform.
+/// Note that this is asymmetric with `generate_bracket_mesh`, which
+/// does bake in `Scale(length)` - vpinball's bracket exporter does
+/// the same, so the bracket needs no additional scaling.
 fn generate_wire_mesh(
     gate: &Gate,
     mesh: &[Vertex3dNoTex2],
     indices: &[u16],
-    scale_by_length: bool,
 ) -> (Vec<VertexWrapper>, Vec<VpxFace>) {
-    // Rotation, optionally scaled (no translation - that goes in node transform).
-    let world_matrix = if scale_by_length {
-        Matrix3D::rotate_z(gate.rotation.to_radians()) * Matrix3D::scale_uniform(gate.length)
-    } else {
-        Matrix3D::rotate_z(gate.rotation.to_radians())
-    };
+    let world_matrix = Matrix3D::rotate_z(gate.rotation.to_radians());
 
     let vertices: Vec<VertexWrapper> = mesh
         .iter()
@@ -190,38 +180,26 @@ pub fn build_gate_meshes(gate: &Gate) -> Option<GateMeshes> {
     if !gate.is_visible {
         return None;
     }
-    Some(build_gate_meshes_inner(
-        gate, /* scale_wire_by_length = */ true,
-    ))
+    build_gate_meshes_unchecked(gate)
 }
 
-/// Like [`build_gate_meshes`] but skips the runtime visibility check
-/// and matches `Gate::GenerateWireMesh` (no length scale on the wire).
+/// Like [`build_gate_meshes`] but skips the runtime visibility check.
 ///
 /// VPinball's `Gate::ExportMesh` does not consult `m_d.m_visible` (the
 /// runtime visibility flag) - it only filters at the table level via
-/// `m_uiVisible`. It also calls `GenerateWireMesh`, which (unlike
-/// `RenderDynamic`) does not multiply the wire by `m_d.m_length`. The
-/// OBJ exporter uses this variant to match byte-for-byte.
+/// `m_uiVisible`. The OBJ exporter uses this variant to match.
 pub(crate) fn build_gate_meshes_unchecked(gate: &Gate) -> Option<GateMeshes> {
-    Some(build_gate_meshes_inner(
-        gate, /* scale_wire_by_length = */ false,
-    ))
-}
-
-fn build_gate_meshes_inner(gate: &Gate, scale_wire_by_length: bool) -> GateMeshes {
-    // Get the appropriate mesh for this gate type (default to WireW if not specified)
     let gate_type = gate.gate_type.as_ref().unwrap_or(&GateType::WireW);
     let (mesh, indices) = get_mesh_for_type(gate_type);
 
-    GateMeshes {
+    Some(GateMeshes {
         bracket: if gate.show_bracket {
             Some(generate_bracket_mesh(gate))
         } else {
             None
         },
-        wire: generate_wire_mesh(gate, mesh, indices, scale_wire_by_length),
-    }
+        wire: generate_wire_mesh(gate, mesh, indices),
+    })
 }
 
 #[cfg(test)]

--- a/src/vpx/mesh/gates/mod.rs
+++ b/src/vpx/mesh/gates/mod.rs
@@ -106,25 +106,35 @@ fn generate_bracket_mesh(gate: &Gate) -> (Vec<VertexWrapper>, Vec<VpxFace>) {
     (vertices, faces)
 }
 
-/// Generate gate wire/plate mesh
+/// Generate gate wire/plate mesh.
 ///
-/// From VPinball Gate::RenderDynamic (line 417-418):
-/// ```cpp
-/// const Matrix3D vertMatrix = (fullMatrix
-///     * Matrix3D::MatrixScale(m_d.m_length, m_d.m_length, m_d.m_length))
-///     * Matrix3D::MatrixTranslate(m_d.m_vCenter.x, m_d.m_vCenter.y, m_d.m_height + m_baseHeight);
-/// ```
+/// Two valid VPinball reference points:
 ///
-/// Note: The wire mesh IS scaled by length, same as the bracket.
-/// Translation is NOT applied here - use gate.center and height for node transform.
+/// - **`Gate::RenderDynamic`** (gate.cpp:417-418) - the in-game renderer.
+///   Applies `RotateZ * Scale(length) * Translate(...)`, so the wire is
+///   scaled by `m_d.m_length`. This is what we want for visual export
+///   targets like glTF.
+/// - **`Gate::GenerateWireMesh`** (gate.cpp:527-531) - the OBJ export
+///   path. Applies only `RotateZ * Translate(...)`, with NO length
+///   scaling (a vpinball quirk: bracket scales, wire doesn't).
+///
+/// `scale_by_length = true` matches the runtime, `false` matches the
+/// vpinball OBJ exporter byte-for-byte.
+///
+/// Translation is NOT applied here - use gate.center and height for the
+/// caller's node/object transform.
 fn generate_wire_mesh(
     gate: &Gate,
     mesh: &[Vertex3dNoTex2],
     indices: &[u16],
+    scale_by_length: bool,
 ) -> (Vec<VertexWrapper>, Vec<VpxFace>) {
-    // Rotation and scale (no translation - that goes in node transform)
-    let world_matrix =
-        Matrix3D::rotate_z(gate.rotation.to_radians()) * Matrix3D::scale_uniform(gate.length);
+    // Rotation, optionally scaled (no translation - that goes in node transform).
+    let world_matrix = if scale_by_length {
+        Matrix3D::rotate_z(gate.rotation.to_radians()) * Matrix3D::scale_uniform(gate.length)
+    } else {
+        Matrix3D::rotate_z(gate.rotation.to_radians())
+    };
 
     let vertices: Vec<VertexWrapper> = mesh
         .iter()
@@ -180,27 +190,38 @@ pub fn build_gate_meshes(gate: &Gate) -> Option<GateMeshes> {
     if !gate.is_visible {
         return None;
     }
-    build_gate_meshes_unchecked(gate)
+    Some(build_gate_meshes_inner(
+        gate, /* scale_wire_by_length = */ true,
+    ))
 }
 
-/// Like [`build_gate_meshes`] but skips the runtime visibility check.
+/// Like [`build_gate_meshes`] but skips the runtime visibility check
+/// and matches `Gate::GenerateWireMesh` (no length scale on the wire).
 ///
 /// VPinball's `Gate::ExportMesh` does not consult `m_d.m_visible` (the
 /// runtime visibility flag) - it only filters at the table level via
-/// `m_uiVisible`. The OBJ exporter uses this variant to match.
+/// `m_uiVisible`. It also calls `GenerateWireMesh`, which (unlike
+/// `RenderDynamic`) does not multiply the wire by `m_d.m_length`. The
+/// OBJ exporter uses this variant to match byte-for-byte.
 pub(crate) fn build_gate_meshes_unchecked(gate: &Gate) -> Option<GateMeshes> {
+    Some(build_gate_meshes_inner(
+        gate, /* scale_wire_by_length = */ false,
+    ))
+}
+
+fn build_gate_meshes_inner(gate: &Gate, scale_wire_by_length: bool) -> GateMeshes {
     // Get the appropriate mesh for this gate type (default to WireW if not specified)
     let gate_type = gate.gate_type.as_ref().unwrap_or(&GateType::WireW);
     let (mesh, indices) = get_mesh_for_type(gate_type);
 
-    Some(GateMeshes {
+    GateMeshes {
         bracket: if gate.show_bracket {
             Some(generate_bracket_mesh(gate))
         } else {
             None
         },
-        wire: generate_wire_mesh(gate, mesh, indices),
-    })
+        wire: generate_wire_mesh(gate, mesh, indices, scale_wire_by_length),
+    }
 }
 
 #[cfg(test)]

--- a/src/vpx/mesh/ramps.rs
+++ b/src/vpx/mesh/ramps.rs
@@ -403,19 +403,23 @@ fn create_wire(
         let i2 = if i == num_rings - 1 { i } else { i + 1 };
         let height = heights[i];
 
-        let tangent = if i == num_rings - 1 && i > 0 {
-            Vec3 {
-                x: mid_points[i].x - mid_points[i - 1].x,
-                y: mid_points[i].y - mid_points[i - 1].y,
-                z: heights[i] - heights[i - 1],
-            }
-        } else {
-            Vec3 {
-                x: mid_points[i2].x - mid_points[i].x,
-                y: mid_points[i2].y - mid_points[i].y,
-                z: heights[i2] - height,
-            }
+        // Match VPinball's `Ramp::CreateWire` (ramp.cpp:1021-1027):
+        // build the tangent from the i2-based delta first (which gives
+        // a (0, 0, 0) tangent at the last ring because i2 = i), then
+        // override ONLY x and y on the last ring with the previous
+        // segment's direction. `tangent.z` is left at 0 there - that's
+        // intentional, it gives the end ring a horizontal tangent and
+        // therefore a vertically-oriented ring plane that matches the
+        // reference output.
+        let mut tangent = Vec3 {
+            x: mid_points[i2].x - mid_points[i].x,
+            y: mid_points[i2].y - mid_points[i].y,
+            z: heights[i2] - height,
         };
+        if i == num_rings - 1 && i > 0 {
+            tangent.x = mid_points[i].x - mid_points[i - 1].x;
+            tangent.y = mid_points[i].y - mid_points[i - 1].y;
+        }
 
         let (normal, binorm) = if i == 0 {
             let up = Vec3 {
@@ -489,13 +493,40 @@ fn build_wire_ramp_mesh(
     let num_segments =
         super::vpinball_ring_segments(detail_level, !material_opacity_active) as usize;
 
-    // Get middle points (center of ramp)
+    // Recover middle points used by VPinball's `Ramp::GenerateWireMesh`.
+    //
+    // VPinball's `GetRampVertex` (ramp.cpp:479) computes
+    // `middlePoints[i] = vmiddle + vnormal` (note: vnormal added in
+    // its un-scaled form, magnitude 1.0 at endpoints / variable
+    // interior). For RampType1Wire it then calls `CreateWire(...,
+    // middlePoints, ...)` (ramp.cpp:1124), so the OneWire spine is
+    // offset from the drag-point centerline by `vnormal`.
+    //
+    // We don't keep `vnormal` directly, but the rgv_local pairs let
+    // us recover both halves: with `widthcur = wire_diameter`,
+    //   rgv_local[i]    = vmiddle + (wire_diameter / 2) * vnormal
+    //   rgv_local[left] = vmiddle - (wire_diameter / 2) * vnormal
+    // so vmiddle is the midpoint and `vnormal = (i - left) /
+    // wire_diameter`. Then `vmiddle + vnormal` matches vpinball.
     let mut mid_points: Vec<Vec2> = Vec::with_capacity(num_rings);
+    let inv_wire_diameter = if ramp.wire_diameter != 0.0 {
+        1.0 / ramp.wire_diameter
+    } else {
+        0.0
+    };
     for i in 0..num_rings {
         let left_idx = num_rings * 2 - i - 1;
-        mid_points.push(Vec2 {
+        let vmiddle = Vec2 {
             x: (rgv_local[i].x + rgv_local[left_idx].x) * 0.5,
             y: (rgv_local[i].y + rgv_local[left_idx].y) * 0.5,
+        };
+        let vnormal = Vec2 {
+            x: (rgv_local[i].x - rgv_local[left_idx].x) * inv_wire_diameter,
+            y: (rgv_local[i].y - rgv_local[left_idx].y) * inv_wire_diameter,
+        };
+        mid_points.push(Vec2 {
+            x: vmiddle.x + vnormal.x,
+            y: vmiddle.y + vnormal.y,
         });
     }
 


### PR DESCRIPTION
Add a shared ExportUnits enum and `units` option for OBJ + glTF export
(OBJ defaults to metres, glTF keeps metres). Read pre-10.8 materials
from the legacy `MATE` chunk so MTL Kd values match vpinball. Fix
primitive matrix order, gate-wire scaling, OneWire ramp spine and
last-ring tangent so all named items match vpinball's reference OBJ
within float rounding. Flip OBJ defaults to DCC-friendly (textures
extracted, `newmtl` deduped, top+side walls split); preserve
byte-faithful behaviour via `ObjExportOptions::vpinball_strict()`.