### PR TITLE
fix(export): apply pre-10.8 playfield-visibility override on export

### DIFF
--- a/src/vpx/compat.rs
+++ b/src/vpx/compat.rs
@@ -1,0 +1,401 @@
+//! Backwards-compatibility shims for tables saved with older
+//! `.vpx` file versions.
+//!
+//! VPinball applies a batch of load-time patches to old tables to
+//! preserve their original rendering. Our `extract` / `assemble`
+//! flows deliberately don't run these patches - they need to
+//! round-trip raw bytes - but the OBJ / glTF exporters want the
+//! same view the runtime renderer sees, otherwise pre-10.8 tables
+//! drop their playfield mesh (and other quirks).
+//!
+//! All current rules come from vpinball's `PinTable::LoadGameFromStorage`
+//! in `src/parts/pintable.cpp:1977-2025`, gated on
+//! `loadfileversion < 1080`. Add new version-gated rules here as
+//! they're discovered.
+//!
+//! Each rule has a helper function below so the call site doesn't
+//! have to remember the version check; helpers fall through to the
+//! stored value for 10.8+ tables. Adding a helper without a
+//! consumer is fine - clippy will flag it as dead but the
+//! module-level `#[allow(dead_code)]` keeps things quiet until the
+//! consumer arrives.
+//!
+//! # Pre-10.8 (`< 1080`) rules
+//!
+//! See vpinball `pintable.cpp:1977-2025`.
+//!
+//! - **Playfield primitives** (any [`Primitive`] whose name matches
+//!   `playfield_mesh`): forced `is_visible = true`,
+//!   `static_rendering = true`, `disable_lighting_below = 1.0`,
+//!   `depth_bias = 100000.0`, `backfaces_enabled = false`.
+//! - **Any primitive with an opaque material**
+//!   (`!opacity_active || opacity == 1.0`): forced
+//!   `disable_lighting_below = 1.0` to compensate for vpinball
+//!   discarding the texture alpha channel under those material
+//!   conditions pre-10.8.
+//! - **All lights**:
+//!     - `reflection_enabled = false` (lights were never reflected
+//!       pre-10.8). The field isn't modelled on our [`Light`]
+//!       struct yet, so no helper.
+//!     - `height = is_bulb_light ? bulb_halo_height : 0.0`
+//!       (pre-10.8 lights had no explicit z; this preserves the
+//!       original falloff curve).
+//!     - If `!is_bulb_light`: `show_bulb_mesh = false`,
+//!       `show_reflection_on_ball = false`.
+//!     - If `!visible`: `show_bulb_mesh = false`.
+//! - **Table glass**: `glass_bottom_height = glass_top_height`
+//!   (glass was horizontal until 10.8).
+
+use crate::vpx::gameitem::light::Light;
+use crate::vpx::gameitem::primitive::Primitive;
+use crate::vpx::version::Version;
+
+/// File version cutoff (`major*100 + minor*10`) for the 10.8
+/// compatibility rules. Vpinball stores this as `loadfileversion`
+/// in `PinTable::LoadGameFromStorage`.
+const VPX_10_8: u32 = 1080;
+
+#[inline]
+fn is_pre_10_8(version: &Version) -> bool {
+    version.u32() < VPX_10_8
+}
+
+// ---------------------------------------------------------------------------
+// Primitive rules
+// ---------------------------------------------------------------------------
+
+/// Effective visibility for an exported primitive, applying the
+/// pre-10.8 playfield-force-visible rule. VPinball ignored
+/// `is_visible` on the playfield mesh until 10.8; any value stored
+/// on a pre-10.8 table is therefore meaningless and we treat the
+/// playfield as visible.
+pub fn primitive_is_visible(primitive: &Primitive, version: &Version) -> bool {
+    if is_pre_10_8(version) && primitive.is_playfield() {
+        return true;
+    }
+    primitive.is_visible
+}
+
+/// Effective `static_rendering` flag. Pre-10.8 vpinball always
+/// rendered the playfield mesh into the static buffer regardless
+/// of this flag.
+#[allow(dead_code)] // no exporter currently reads `static_rendering`
+pub fn primitive_static_rendering(primitive: &Primitive, version: &Version) -> bool {
+    if is_pre_10_8(version) && primitive.is_playfield() {
+        return true;
+    }
+    primitive.static_rendering
+}
+
+/// Effective `depth_bias`. Pre-10.8 vpinball rendered the
+/// playfield before everything else, equivalent to a very large
+/// depth bias.
+#[allow(dead_code)] // no exporter currently reads `depth_bias`
+pub fn primitive_depth_bias(primitive: &Primitive, version: &Version) -> f32 {
+    if is_pre_10_8(version) && primitive.is_playfield() {
+        return 100_000.0;
+    }
+    primitive.depth_bias
+}
+
+/// Effective `backfaces_enabled`. Pre-10.8 playfield meshes did
+/// not handle back faces.
+#[allow(dead_code)] // no exporter currently reads `backfaces_enabled`
+pub fn primitive_backfaces_enabled(primitive: &Primitive, version: &Version) -> Option<bool> {
+    if is_pre_10_8(version) && primitive.is_playfield() {
+        return Some(false);
+    }
+    primitive.backfaces_enabled
+}
+
+/// Effective `disable_lighting_below`. Two pre-10.8 rules combine:
+/// the playfield always blocks under-lighting (since playfields
+/// rendered before the bulb-light buffer), and any primitive with
+/// a fully-opaque material also blocks it (vpinball discarded the
+/// texture alpha when the material had no active opacity).
+///
+/// `material_opacity` is `Some((opacity_active, opacity))` when the
+/// caller resolved the primitive's material, `None` when no
+/// material was found - matching vpinball's `if (mat && ...)`
+/// null check, which skips the force when the material is missing.
+pub fn primitive_disable_lighting_below(
+    primitive: &Primitive,
+    material_opacity: Option<(bool, f32)>,
+    version: &Version,
+) -> Option<f32> {
+    if is_pre_10_8(version) {
+        if primitive.is_playfield() {
+            return Some(1.0);
+        }
+        if let Some((opacity_active, opacity)) = material_opacity
+            && (!opacity_active || opacity == 1.0)
+        {
+            return Some(1.0);
+        }
+    }
+    primitive.disable_lighting_below
+}
+
+// ---------------------------------------------------------------------------
+// Light rules
+// ---------------------------------------------------------------------------
+
+/// Effective light height. Pre-10.8 lights had no z coordinate;
+/// the runtime applied `is_bulb_light ? bulb_halo_height : 0.0`
+/// so the falloff curve matched the historical render offset.
+/// Any stored `height` on an old table is therefore meaningless.
+pub fn light_height(light: &Light, version: &Version) -> Option<f32> {
+    if is_pre_10_8(version) {
+        return Some(if light.is_bulb_light {
+            light.bulb_halo_height
+        } else {
+            0.0
+        });
+    }
+    light.height
+}
+
+/// Effective `show_bulb_mesh` flag. Two pre-10.8 rules combine:
+/// classic (non-bulb) lights could not have a bulb mesh, and any
+/// light explicitly marked invisible did not render its bulb
+/// mesh either.
+pub fn light_show_bulb_mesh(light: &Light, version: &Version) -> bool {
+    if is_pre_10_8(version) {
+        if !light.is_bulb_light {
+            return false;
+        }
+        if !light.visible.unwrap_or(true) {
+            return false;
+        }
+    }
+    light.show_bulb_mesh
+}
+
+/// Effective `show_reflection_on_ball`. Pre-10.8 classic lights
+/// could not have ball reflections.
+#[allow(dead_code)] // no exporter currently reads `show_reflection_on_ball`
+pub fn light_show_reflection_on_ball(light: &Light, version: &Version) -> bool {
+    if is_pre_10_8(version) && !light.is_bulb_light {
+        return false;
+    }
+    light.show_reflection_on_ball
+}
+
+// ---------------------------------------------------------------------------
+// Table-level rules
+// ---------------------------------------------------------------------------
+
+/// Effective glass bottom height. The glass was horizontal until
+/// 10.8, so for older tables vpinball collapses
+/// `glass_bottom_height` onto `glass_top_height`. From 10.8 the
+/// table author can tilt the glass and the stored field is honoured
+/// (falling back to the top height when absent for very old tables
+/// that don't carry the field at all).
+#[allow(dead_code)] // no exporter currently reads `glass_bottom_height`
+pub fn glass_bottom_height(
+    glass_top_height: f32,
+    glass_bottom_height: Option<f32>,
+    version: &Version,
+) -> f32 {
+    if is_pre_10_8(version) {
+        return glass_top_height;
+    }
+    glass_bottom_height.unwrap_or(glass_top_height)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn version(v: &str) -> Version {
+        Version::parse(v).unwrap()
+    }
+
+    // --- Primitive ----------------------------------------------------------
+
+    fn primitive(name: &str) -> Primitive {
+        Primitive {
+            name: name.to_string(),
+            ..Primitive::default()
+        }
+    }
+
+    #[test]
+    fn pre_10_8_forces_playfield_visible_only() {
+        let mut p = primitive("playfield_mesh");
+        p.is_visible = false;
+        assert!(primitive_is_visible(&p, &version("1072")));
+
+        let mut other = primitive("SomePrimitive");
+        other.is_visible = false;
+        assert!(!primitive_is_visible(&other, &version("1072")));
+    }
+
+    #[test]
+    fn post_10_8_honours_stored_visibility() {
+        let mut p = primitive("playfield_mesh");
+        p.is_visible = false;
+        for v in ["1080", "1081"] {
+            assert!(!primitive_is_visible(&p, &version(v)));
+        }
+    }
+
+    #[test]
+    fn playfield_match_is_case_insensitive() {
+        let p = primitive("Playfield_Mesh");
+        assert!(primitive_is_visible(&p, &version("1072")));
+    }
+
+    #[test]
+    fn pre_10_8_forces_playfield_static_depth_backfaces() {
+        let p = primitive("playfield_mesh");
+        assert!(primitive_static_rendering(&p, &version("1072")));
+        assert_eq!(primitive_depth_bias(&p, &version("1072")), 100_000.0);
+        assert_eq!(
+            primitive_backfaces_enabled(&p, &version("1072")),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn post_10_8_keeps_stored_static_depth_backfaces() {
+        let mut p = primitive("playfield_mesh");
+        p.static_rendering = false;
+        p.depth_bias = 42.0;
+        p.backfaces_enabled = Some(true);
+        assert!(!primitive_static_rendering(&p, &version("1080")));
+        assert_eq!(primitive_depth_bias(&p, &version("1080")), 42.0);
+        assert_eq!(
+            primitive_backfaces_enabled(&p, &version("1080")),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn pre_10_8_disable_lighting_below_playfield() {
+        let p = primitive("playfield_mesh");
+        assert_eq!(
+            primitive_disable_lighting_below(&p, Some((true, 0.5)), &version("1072")),
+            Some(1.0)
+        );
+    }
+
+    #[test]
+    fn pre_10_8_disable_lighting_below_opaque_material() {
+        // Material with opacity 1.0 -> forced 1.0.
+        let p = primitive("Other");
+        assert_eq!(
+            primitive_disable_lighting_below(&p, Some((true, 1.0)), &version("1072")),
+            Some(1.0)
+        );
+        // Material with opacity_active=false -> also forced.
+        assert_eq!(
+            primitive_disable_lighting_below(&p, Some((false, 0.5)), &version("1072")),
+            Some(1.0)
+        );
+        // Active translucent material -> stored value passes through.
+        let mut p2 = primitive("Other");
+        p2.disable_lighting_below = Some(0.25);
+        assert_eq!(
+            primitive_disable_lighting_below(&p2, Some((true, 0.5)), &version("1072")),
+            Some(0.25)
+        );
+    }
+
+    #[test]
+    fn pre_10_8_missing_material_does_not_force() {
+        // Mirrors vpinball's `if (mat && ...)` null check - missing
+        // material means the opaque-material rule doesn't fire.
+        let p = primitive("Other");
+        assert_eq!(
+            primitive_disable_lighting_below(&p, None, &version("1072")),
+            None
+        );
+    }
+
+    #[test]
+    fn post_10_8_disable_lighting_below_passes_through() {
+        let mut p = primitive("playfield_mesh");
+        p.disable_lighting_below = Some(0.5);
+        // Even for the playfield, 10.8+ trusts the stored value.
+        assert_eq!(
+            primitive_disable_lighting_below(&p, Some((true, 1.0)), &version("1080")),
+            Some(0.5)
+        );
+    }
+
+    // --- Light --------------------------------------------------------------
+
+    fn light_with(is_bulb: bool, visible: Option<bool>) -> Light {
+        Light {
+            is_bulb_light: is_bulb,
+            visible,
+            show_bulb_mesh: true,
+            show_reflection_on_ball: true,
+            bulb_halo_height: 50.0,
+            height: Some(99.0),
+            ..Light::default()
+        }
+    }
+
+    #[test]
+    fn pre_10_8_light_height_classic_is_zero() {
+        let l = light_with(false, Some(true));
+        assert_eq!(light_height(&l, &version("1072")), Some(0.0));
+    }
+
+    #[test]
+    fn pre_10_8_light_height_bulb_uses_halo_height() {
+        let l = light_with(true, Some(true));
+        assert_eq!(light_height(&l, &version("1072")), Some(50.0));
+    }
+
+    #[test]
+    fn post_10_8_light_height_passes_through() {
+        let l = light_with(false, Some(true));
+        assert_eq!(light_height(&l, &version("1080")), Some(99.0));
+    }
+
+    #[test]
+    fn pre_10_8_classic_lights_drop_bulb_mesh_and_reflection() {
+        let l = light_with(false, Some(true));
+        assert!(!light_show_bulb_mesh(&l, &version("1072")));
+        assert!(!light_show_reflection_on_ball(&l, &version("1072")));
+    }
+
+    #[test]
+    fn pre_10_8_invisible_lights_drop_bulb_mesh() {
+        let l = light_with(true, Some(false));
+        assert!(!light_show_bulb_mesh(&l, &version("1072")));
+        // Bulb light reflection isn't gated on visibility, so it survives.
+        assert!(light_show_reflection_on_ball(&l, &version("1072")));
+    }
+
+    #[test]
+    fn post_10_8_lights_pass_through() {
+        let l = light_with(false, Some(false));
+        assert!(light_show_bulb_mesh(&l, &version("1080")));
+        assert!(light_show_reflection_on_ball(&l, &version("1080")));
+    }
+
+    // --- Glass --------------------------------------------------------------
+
+    #[test]
+    fn pre_10_8_glass_is_horizontal() {
+        assert_eq!(
+            glass_bottom_height(210.0, Some(100.0), &version("1072")),
+            210.0
+        );
+        assert_eq!(glass_bottom_height(210.0, None, &version("1072")), 210.0);
+    }
+
+    #[test]
+    fn post_10_8_glass_uses_stored_bottom() {
+        assert_eq!(
+            glass_bottom_height(210.0, Some(100.0), &version("1080")),
+            100.0
+        );
+        // Missing field falls back to top height.
+        assert_eq!(glass_bottom_height(210.0, None, &version("1080")), 210.0);
+    }
+}

--- a/src/vpx/export/gltf_export.rs
+++ b/src/vpx/export/gltf_export.rs
@@ -579,6 +579,30 @@ fn calculate_transmission_factor(disable_lighting_below: Option<f32>) -> Option<
         .map(|v| (1.0 - v) * MAX_TRANSMISSION)
 }
 
+/// Resolve `(opacity_active, opacity)` for a material by name,
+/// looking in the new `MATR` chunk first and falling back to the
+/// legacy `MATE` chunk. `None` for empty/unknown names - mirrors
+/// vpinball's `GetMaterial`, which returns null in that case.
+/// Used by the pre-10.8 compat helper
+/// [`crate::vpx::compat::primitive_disable_lighting_below`].
+fn lookup_material_opacity(vpx: &VPX, name: &str) -> Option<(bool, f32)> {
+    if name.is_empty() {
+        return None;
+    }
+    if let Some(mats) = &vpx.gamedata.materials
+        && let Some(m) = mats.iter().find(|m| m.name.eq_ignore_ascii_case(name))
+    {
+        return Some((m.opacity_active, m.opacity));
+    }
+    for m in &vpx.gamedata.materials_old {
+        if m.name.eq_ignore_ascii_case(name) {
+            let opacity_active = (m.opacity_active_edge_alpha & 1) != 0;
+            return Some((opacity_active, m.opacity));
+        }
+    }
+    None
+}
+
 /// Calculate playfield roughness from VPinball's reflection strength.
 ///
 /// VPinball's playfield reflections are a separate screen-space effect that renders
@@ -777,7 +801,8 @@ fn collect_meshes(vpx: &VPX, options: &GltfExportOptions) -> (Vec<NamedMesh>, Ve
     for gameitem in &vpx.gameitems {
         match gameitem {
             GameItemEnum::Primitive(primitive) => {
-                if !options.export_invisible_items && !primitive.is_visible {
+                let visible = crate::vpx::compat::primitive_is_visible(primitive, &vpx.version);
+                if !options.export_invisible_items && !visible {
                     continue;
                 }
                 if let Ok(Some(read_mesh)) = effective_primitive_mesh(primitive) {
@@ -823,8 +848,19 @@ fn collect_meshes(vpx: &VPX, options: &GltfExportOptions) -> (Vec<NamedMesh>, Ve
                         (material, texture)
                     };
 
+                    // Route through compat: pre-10.8 vpinball forces
+                    // disable_lighting_below to 1.0 for the playfield, and
+                    // for any primitive whose material is fully opaque
+                    // (alpha-discard compensation, pintable.cpp:1984-1990).
+                    let material_opacity = lookup_material_opacity(vpx, &primitive.material);
+                    let effective_disable_lighting_below =
+                        crate::vpx::compat::primitive_disable_lighting_below(
+                            primitive,
+                            material_opacity,
+                            &vpx.version,
+                        );
                     let transmission_factor =
-                        calculate_transmission_factor(primitive.disable_lighting_below);
+                        calculate_transmission_factor(effective_disable_lighting_below);
 
                     meshes.push(NamedMesh {
                         name: primitive.name.clone(),
@@ -835,7 +871,7 @@ fn collect_meshes(vpx: &VPX, options: &GltfExportOptions) -> (Vec<NamedMesh>, Ve
                         layer_name: prim_layer_name,
                         transmission_factor,
                         translation: Some(translation),
-                        visible: primitive.is_visible,
+                        visible,
                         group_name: Some(primitive.name.clone()),
                         ..Default::default()
                     });
@@ -1421,8 +1457,11 @@ fn collect_meshes(vpx: &VPX, options: &GltfExportOptions) -> (Vec<NamedMesh>, Ve
                 let light_layer_name = group_info.layer_name.clone();
                 item_groups.push(group_info);
 
-                // Generate bulb meshes for lights with show_bulb_mesh enabled
-                if light.show_bulb_mesh
+                // Generate bulb meshes for lights with show_bulb_mesh enabled.
+                // Routed through compat so pre-10.8 classic / invisible lights
+                // don't get a spurious bulb mesh (matches vpinball's load-time
+                // overrides in pintable.cpp:1977-2024).
+                if crate::vpx::compat::light_show_bulb_mesh(light, &vpx.version)
                     && let Some(light_meshes) = build_light_meshes(light)
                 {
                     // Convert center to glTF coordinates (meters, Y-up)
@@ -2694,8 +2733,12 @@ fn build_combined_gltf_payload(
             let surface_height =
                 get_surface_height(vpx, &light.surface, light.center.x, light.center.y);
 
-            // Get light height offset (use provided height or default to 0)
-            let mut light_height_offset = light.height.unwrap_or(0.0);
+            // Get light height offset (use provided height or default to 0).
+            // Routed through compat so pre-10.8 lights use the historical
+            // `is_bulb_light ? bulb_halo_height : 0.0` instead of the stored
+            // value, which was meaningless on old tables.
+            let mut light_height_offset =
+                crate::vpx::compat::light_height(light, &vpx.version).unwrap_or(0.0);
 
             // If a GI light has height 0, move the light up ~1cm
             // so it appears inside the bulb rather than at the base

--- a/src/vpx/export/obj_export.rs
+++ b/src/vpx/export/obj_export.rs
@@ -445,7 +445,7 @@ fn write_primitive<O: ObjWriter<f32>, M: MtlWriter<f32>>(
     fs: &dyn FileSystem,
     primitive: &Primitive,
 ) -> io::Result<()> {
-    if !primitive.is_visible {
+    if !crate::vpx::compat::primitive_is_visible(primitive, &state.vpx.version) {
         return Ok(());
     }
     let read = match effective_primitive_mesh(primitive) {

--- a/src/vpx/mod.rs
+++ b/src/vpx/mod.rs
@@ -47,6 +47,7 @@ use self::version::{read_version, write_version};
 pub mod biff;
 pub mod collection;
 pub mod color;
+pub(crate) mod compat;
 pub mod custominfotags;
 pub mod expanded;
 pub mod font;


### PR DESCRIPTION
VPinball patches a batch of fields on tables saved before file version 1080 to preserve their original rendering
(`pintable.cpp:1977-2025`). The most user-visible rule:

  if (loadfileversion < 1080) { ... prim->put_Visible(FTOVB(true)); ... }

forces playfield-mesh primitives visible, because pre-10.8 vpinball ignored the `is_visible` flag on the playfield entirely (it always rendered). Any saved value on an old table is therefore stale; for a 10.8+ table the user can genuinely hide it and we honour that.

Our OBJ / glTF exporters were dropping the playfield mesh when an old table happened to carry `is_visible = false`. Add `vpx::compat::primitive_is_visible(prim, version)` (gated on `< 1080`) and route both exporters through it.

The module docstring also catalogues the rest of the pre-10.8 rules vpinball applies (lighting, depth bias, glass, light reflection, ...) so future ports have a single place to look. Only the visibility helper is wired up; the others get added on demand.

The patches deliberately don't run from `vpx::read` / `expanded` flows - those need to round-trip raw bytes - only from the render-facing export paths.