### PR TITLE
chore: release v0.26.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.1](https://github.com/francisdb/vpin/compare/v0.26.0...v0.26.1) - 2026-05-13
+
+### Added
+
+- *(gameitem)* expose image/material/visibility accessors on GameItemEnum ([#306](https://github.com/francisdb/vpin/pull/306))
+
+### Fixed
+
+- *(export)* apply pre-10.8 playfield-visibility override on export ([#304](https://github.com/francisdb/vpin/pull/304))
+
 ## [0.26.0](https://github.com/francisdb/vpin/compare/v0.25.0...v0.26.0) - 2026-05-08
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vpin"
-version = "0.26.0"
+version = "0.26.1"
 edition = "2024"
 description = "Rust library for working with Visual Pinball VPX files"
 repository = "https://github.com/francisdb/vpin"


### PR DESCRIPTION



## 🤖 New release

* `vpin`: 0.26.0 -> 0.26.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.1](https://github.com/francisdb/vpin/compare/v0.26.0...v0.26.1) - 2026-05-13

### Added

- *(gameitem)* expose image/material/visibility accessors on GameItemEnum ([#306](https://github.com/francisdb/vpin/pull/306))

### Fixed

- *(export)* apply pre-10.8 playfield-visibility override on export ([#304](https://github.com/francisdb/vpin/pull/304))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).