### PR TITLE
perf(expanded): buffer JSON writes and flush explicitly

### DIFF
--- a/src/vpx/expanded/fonts.rs
+++ b/src/vpx/expanded/fonts.rs
@@ -3,7 +3,7 @@
 use crate::filesystem::FileSystem;
 use crate::vpx::font::{FontData, FontDataJson};
 use log::info;
-use std::io::{self, Write};
+use std::io::{self, BufWriter, Write};
 use std::path::Path;
 
 use super::WriteError;
@@ -15,9 +15,11 @@ pub(super) fn write_fonts<P: AsRef<Path>>(
     fs: &dyn FileSystem,
 ) -> Result<(), WriteError> {
     let fonts_json_path = expanded_dir.as_ref().join("fonts.json");
-    let mut fonts_index_file = fs.create_file(&fonts_json_path)?;
+    let fonts_index_file = fs.create_file(&fonts_json_path)?;
+    let mut fonts_index_writer = BufWriter::new(fonts_index_file);
     let fonts_index: Vec<FontDataJson> = fonts.iter().map(FontDataJson::from_font_data).collect();
-    serde_json::to_writer_pretty(&mut fonts_index_file, &fonts_index)?;
+    serde_json::to_writer_pretty(&mut fonts_index_writer, &fonts_index)?;
+    fonts_index_writer.flush()?;
 
     let fonts_dir = expanded_dir.as_ref().join("fonts");
     fs.create_dir_all(&fonts_dir)?;

--- a/src/vpx/expanded/gameitems.rs
+++ b/src/vpx/expanded/gameitems.rs
@@ -6,7 +6,7 @@ use log::info;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use std::collections::HashSet;
-use std::io;
+use std::io::{self, BufWriter, Write};
 use std::path::Path;
 use tracing::instrument;
 
@@ -98,8 +98,10 @@ pub(super) fn write_gameitems<P: AsRef<Path>>(
     }
 
     let gameitems_index_path = expanded_dir.as_ref().join("gameitems.json");
-    let mut gameitems_index_file = fs.create_file(&gameitems_index_path)?;
-    serde_json::to_writer_pretty(&mut gameitems_index_file, &files)?;
+    let gameitems_index_file = fs.create_file(&gameitems_index_path)?;
+    let mut gameitems_index_writer = BufWriter::new(gameitems_index_file);
+    serde_json::to_writer_pretty(&mut gameitems_index_writer, &files)?;
+    gameitems_index_writer.flush()?;
 
     let gameitems_ref = gameitems;
     let gameitems_dir_clone = gameitems_dir.clone();

--- a/src/vpx/expanded/images.rs
+++ b/src/vpx/expanded/images.rs
@@ -6,7 +6,7 @@ use crate::vpx::lzw::to_lzw_blocks;
 use log::{debug, info, warn};
 use std::collections::HashSet;
 use std::ffi::OsStr;
-use std::io::{self, BufRead, Seek};
+use std::io::{self, BufRead, BufWriter, Seek, Write};
 use std::path::Path;
 
 use super::WriteError;
@@ -26,7 +26,8 @@ pub(super) fn write_images<P: AsRef<Path>>(
     info!("Starting image processing - total images: {}", images.len());
 
     let images_index_path = expanded_dir.as_ref().join("images.json");
-    let mut images_index_file = fs.create_file(&images_index_path)?;
+    let images_index_file = fs.create_file(&images_index_path)?;
+    let mut images_index_writer = BufWriter::new(images_index_file);
     let mut image_names_lower: HashSet<String> = HashSet::new();
     let mut image_names_dupe_counter = 0;
     let mut json_images = Vec::with_capacity(images.len());
@@ -110,7 +111,8 @@ pub(super) fn write_images<P: AsRef<Path>>(
         })
         .collect();
     let images_list = images_list?;
-    serde_json::to_writer_pretty(&mut images_index_file, &json_images)?;
+    serde_json::to_writer_pretty(&mut images_index_writer, &json_images)?;
+    images_index_writer.flush()?;
 
     let images_dir = expanded_dir.as_ref().join("images");
     fs.create_dir_all(&images_dir)?;

--- a/src/vpx/expanded/materials.rs
+++ b/src/vpx/expanded/materials.rs
@@ -5,7 +5,7 @@ use crate::vpx::material::{
     Material, MaterialJson, SaveMaterial, SaveMaterialJson, SavePhysicsMaterial,
     SavePhysicsMaterialJson,
 };
-use std::io;
+use std::io::{self, BufWriter, Write};
 use std::path::Path;
 
 use super::WriteError;
@@ -16,10 +16,12 @@ pub(super) fn write_materials<P: AsRef<Path>>(
     fs: &dyn FileSystem,
 ) -> Result<(), WriteError> {
     let materials_path = expanded_dir.as_ref().join("materials.json");
-    let mut materials_file = fs.create_file(&materials_path)?;
+    let materials_file = fs.create_file(&materials_path)?;
+    let mut materials_writer = BufWriter::new(materials_file);
     let materials_index: Vec<MaterialJson> =
         materials.iter().map(MaterialJson::from_material).collect();
-    serde_json::to_writer_pretty(&mut materials_file, &materials_index)?;
+    serde_json::to_writer_pretty(&mut materials_writer, &materials_index)?;
+    materials_writer.flush()?;
     Ok(())
 }
 
@@ -56,12 +58,14 @@ fn write_old_materials<P: AsRef<Path>>(
     fs: &dyn FileSystem,
 ) -> Result<(), WriteError> {
     let materials_path = expanded_dir.as_ref().join("materials-old.json");
-    let mut materials_file = fs.create_file(&materials_path)?;
+    let materials_file = fs.create_file(&materials_path)?;
+    let mut materials_writer = BufWriter::new(materials_file);
     let materials_index: Vec<SaveMaterialJson> = materials_old
         .iter()
         .map(SaveMaterialJson::from_save_material)
         .collect();
-    serde_json::to_writer_pretty(&mut materials_file, &materials_index)?;
+    serde_json::to_writer_pretty(&mut materials_writer, &materials_index)?;
+    materials_writer.flush()?;
     Ok(())
 }
 
@@ -89,12 +93,14 @@ fn write_old_materials_physics<P: AsRef<Path>>(
 ) -> Result<(), WriteError> {
     if let Some(materials) = materials_physics_old {
         let materials_path = expanded_dir.as_ref().join("materials-physics-old.json");
-        let mut materials_file = fs.create_file(&materials_path)?;
+        let materials_file = fs.create_file(&materials_path)?;
+        let mut materials_writer = BufWriter::new(materials_file);
         let materials_index: Vec<SavePhysicsMaterialJson> = materials
             .iter()
             .map(SavePhysicsMaterialJson::from_save_physics_material)
             .collect();
-        serde_json::to_writer_pretty(&mut materials_file, &materials_index)?;
+        serde_json::to_writer_pretty(&mut materials_writer, &materials_index)?;
+        materials_writer.flush()?;
     }
     Ok(())
 }

--- a/src/vpx/expanded/metadata.rs
+++ b/src/vpx/expanded/metadata.rs
@@ -9,7 +9,7 @@ use crate::vpx::renderprobe::{RenderProbeJson, RenderProbeWithGarbage};
 use crate::vpx::tableinfo::TableInfo;
 use log::info;
 use serde_json::Value;
-use std::io::{self, Write};
+use std::io::{self, BufWriter, Write};
 use std::path::Path;
 
 use super::WriteError;
@@ -21,9 +21,11 @@ pub(super) fn write_game_data<P: AsRef<Path>>(
     fs: &dyn FileSystem,
 ) -> Result<(), WriteError> {
     let game_data_path = expanded_dir.as_ref().join("gamedata.json");
-    let mut game_data_file = fs.create_file(&game_data_path)?;
+    let game_data_file = fs.create_file(&game_data_path)?;
+    let mut game_data_writer = BufWriter::new(game_data_file);
     let json = GameDataJson::from_game_data(gamedata);
-    serde_json::to_writer_pretty(&mut game_data_file, &json)?;
+    serde_json::to_writer_pretty(&mut game_data_writer, &json)?;
+    game_data_writer.flush()?;
     let script_path = expanded_dir.as_ref().join("script.vbs");
     let mut script_file = fs.create_file(&script_path)?;
     let script_bytes: Vec<u8> = gamedata.code.clone().into();
@@ -57,9 +59,11 @@ pub(super) fn write_info<P: AsRef<Path>>(
     fs: &dyn FileSystem,
 ) -> Result<(), WriteError> {
     let json_path = expanded_dir.as_ref().join("info.json");
-    let mut json_file = fs.create_file(&json_path)?;
+    let json_file = fs.create_file(&json_path)?;
+    let mut json_writer = BufWriter::new(json_file);
     let info = info_to_json(info, custominfotags);
-    serde_json::to_writer_pretty(&mut json_file, &info)?;
+    serde_json::to_writer_pretty(&mut json_writer, &info)?;
+    json_writer.flush()?;
     Ok(())
 }
 
@@ -83,9 +87,11 @@ pub(super) fn write_collections<P: AsRef<Path>>(
     fs: &dyn FileSystem,
 ) -> Result<(), WriteError> {
     let collections_json_path = expanded_dir.as_ref().join("collections.json");
-    let mut collections_json_file = fs.create_file(&collections_json_path)?;
+    let collections_json_file = fs.create_file(&collections_json_path)?;
+    let mut collections_json_writer = BufWriter::new(collections_json_file);
     let json_collections = collections_json(collections);
-    serde_json::to_writer_pretty(&mut collections_json_file, &json_collections)?;
+    serde_json::to_writer_pretty(&mut collections_json_writer, &json_collections)?;
+    collections_json_writer.flush()?;
     Ok(())
 }
 
@@ -110,12 +116,14 @@ pub(super) fn write_renderprobes<P: AsRef<Path>>(
 ) -> Result<(), WriteError> {
     if let Some(renderprobes) = render_probes {
         let renderprobes_path = expanded_dir.as_ref().join("renderprobes.json");
-        let mut renderprobes_file = fs.create_file(&renderprobes_path)?;
+        let renderprobes_file = fs.create_file(&renderprobes_path)?;
+        let mut renderprobes_writer = BufWriter::new(renderprobes_file);
         let renderprobes_index: Vec<RenderProbeJson> = renderprobes
             .iter()
             .map(RenderProbeJson::from_renderprobe)
             .collect();
-        serde_json::to_writer_pretty(&mut renderprobes_file, &renderprobes_index)?;
+        serde_json::to_writer_pretty(&mut renderprobes_writer, &renderprobes_index)?;
+        renderprobes_writer.flush()?;
     }
     Ok(())
 }

--- a/src/vpx/expanded/sounds.rs
+++ b/src/vpx/expanded/sounds.rs
@@ -4,7 +4,7 @@ use crate::filesystem::FileSystem;
 use crate::vpx::sound::{SoundData, SoundDataJson, read_sound, write_sound};
 use log::info;
 use std::collections::HashSet;
-use std::io::{self, Write};
+use std::io::{self, BufWriter, Write};
 use std::path::Path;
 
 use super::WriteError;
@@ -16,7 +16,8 @@ pub(super) fn write_sounds<P: AsRef<Path>>(
     fs: &dyn FileSystem,
 ) -> Result<(), WriteError> {
     let sounds_index_path = expanded_dir.as_ref().join("sounds.json");
-    let mut sounds_index_file = fs.create_file(&sounds_index_path)?;
+    let sounds_index_file = fs.create_file(&sounds_index_path)?;
+    let mut sounds_index_writer = BufWriter::new(sounds_index_file);
     let mut sound_names_lower: HashSet<String> = HashSet::new();
     let mut sound_names_dupe_counter = 0;
     let mut json_sounds = Vec::with_capacity(sounds.len());
@@ -50,7 +51,8 @@ pub(super) fn write_sounds<P: AsRef<Path>>(
             (file_name, sound)
         })
         .collect();
-    serde_json::to_writer_pretty(&mut sounds_index_file, &json_sounds)?;
+    serde_json::to_writer_pretty(&mut sounds_index_writer, &json_sounds)?;
+    sounds_index_writer.flush()?;
 
     let sounds_dir = expanded_dir.as_ref().join("sounds");
     fs.create_dir_all(&sounds_dir)?;


### PR DESCRIPTION
## Summary

- Wrap every `serde_json::to_writer_pretty` site in `src/vpx/expanded/` in a `BufWriter` and call `flush()?` afterwards.
- Pretty-printed JSON emits many tiny writes (one per token). Previously these went unbuffered to whatever the `FileSystem` returned - fine on local SSD but slow on NAS / network mounts where each `write()` is millisecond-scale.
- The explicit `flush()?` also surfaces write errors that `File`'s `Drop` would otherwise swallow silently - a small correctness win regardless of where the file lives.

## Touched sites

All in `src/vpx/expanded/`:

- `fonts.rs` - fonts index
- `materials.rs` - current, legacy, and legacy-physics material indexes
- `metadata.rs` - gamedata, info, collections, renderprobes
- `sounds.rs` - sounds index
- `images.rs` - images index
- `gameitems.rs` - gameitems index

Binary `write_all` sites (sound data, font data, screenshot, script, version, image data) are deliberately left alone - they're single syscalls already.

## Notes

- `MemoryFileSystem` is now double-buffered (its writer is `Vec<u8>`-backed, then wrapped in `BufWriter`). Harmless: the extra ~8KB buffer is freed when the function returns, and the extra `memcpy` is faster than any syscall it could have replaced.
- The `FileSystem::create_file` trait contract is unchanged - buffering happens at each call site, so consumers implementing the trait keep full control over what they hand back.

Closes #285

## Test plan

- [x] `cargo build` - clean
- [x] `cargo clippy --all-targets` - clean
- [x] `cargo test --lib` - all 354 tests pass
- [ ] Optional manual check: expand a real VPX on a NAS mount and confirm timing improves