### PR TITLE
chore: release v0.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.2](https://github.com/francisdb/vpin/compare/v0.26.1...v0.26.2) - 2026-05-14
+
+### Other
+
+- disable rust-cache cache-bin to fix macOS build ([#312](https://github.com/francisdb/vpin/pull/312))
+- *(filesystem)* move buffering policy into FileSystem trait ([#311](https://github.com/francisdb/vpin/pull/311))
+- *(expanded)* buffer JSON writes and flush explicitly ([#308](https://github.com/francisdb/vpin/pull/308))
+
 ## [0.26.1](https://github.com/francisdb/vpin/compare/v0.26.0...v0.26.1) - 2026-05-13
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vpin"
-version = "0.26.1"
+version = "0.26.2"
 edition = "2024"
 description = "Rust library for working with Visual Pinball VPX files"
 repository = "https://github.com/francisdb/vpin"


### PR DESCRIPTION



## 🤖 New release

* `vpin`: 0.26.1 -> 0.26.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.2](https://github.com/francisdb/vpin/compare/v0.26.1...v0.26.2) - 2026-05-14

### Other

- disable rust-cache cache-bin to fix macOS build ([#312](https://github.com/francisdb/vpin/pull/312))
- *(filesystem)* move buffering policy into FileSystem trait ([#311](https://github.com/francisdb/vpin/pull/311))
- *(expanded)* buffer JSON writes and flush explicitly ([#308](https://github.com/francisdb/vpin/pull/308))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).