### PR TITLE
refactor(filesystem): move buffering policy into FileSystem trait

### DIFF
--- a/src/filesystem.rs
+++ b/src/filesystem.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{self, Cursor, Read, Write};
+use std::io::{self, BufReader, BufWriter, Cursor, Read, Write};
 use std::path::Path;
 use std::sync::{Arc, RwLock};
 
@@ -11,6 +11,25 @@ pub trait FileSystem: Sync {
     fn write_file(&self, path: &Path, data: &[u8]) -> io::Result<()>;
     fn create_dir_all(&self, path: &Path) -> io::Result<()>;
     fn exists(&self, path: &Path) -> bool;
+
+    /// Writer suitable for many small writes. Default impl wraps
+    /// [`create_file`](Self::create_file) in a [`BufWriter`]. Implementations whose
+    /// writer already buffers (e.g. an in-memory [`Vec<u8>`]-backed one) can
+    /// override to skip the extra layer.
+    ///
+    /// Callers should still invoke `flush()?` before dropping the writer:
+    /// errors from a `Drop`-time flush are otherwise swallowed.
+    fn create_buffered_file(&self, path: &Path) -> io::Result<Box<dyn Write>> {
+        Ok(Box::new(BufWriter::new(self.create_file(path)?)))
+    }
+
+    /// Reader suitable for many small reads. Default impl wraps
+    /// [`open_file`](Self::open_file) in a [`BufReader`]. Implementations whose
+    /// reader already serves bytes from memory (e.g. a [`Cursor`] over a
+    /// [`Vec<u8>`]) can override to skip the extra layer.
+    fn open_buffered_file(&self, path: &Path) -> io::Result<Box<dyn Read>> {
+        Ok(Box::new(BufReader::new(self.open_file(path)?)))
+    }
 }
 
 pub struct RealFileSystem;
@@ -196,6 +215,17 @@ impl FileSystem for MemoryFileSystem {
         let path_str = path.to_string_lossy().to_string();
         let files = self.files.read().unwrap();
         files.contains_key(&path_str)
+    }
+
+    // The in-memory writer is already Vec<u8>-backed and the reader is a Cursor
+    // over a Vec<u8>; both serve bytes without syscalls, so an extra BufWriter
+    // / BufReader layer would be pure overhead.
+    fn create_buffered_file(&self, path: &Path) -> io::Result<Box<dyn Write>> {
+        self.create_file(path)
+    }
+
+    fn open_buffered_file(&self, path: &Path) -> io::Result<Box<dyn Read>> {
+        self.open_file(path)
     }
 }
 

--- a/src/vpx/expanded/fonts.rs
+++ b/src/vpx/expanded/fonts.rs
@@ -3,7 +3,7 @@
 use crate::filesystem::FileSystem;
 use crate::vpx::font::{FontData, FontDataJson};
 use log::info;
-use std::io::{self, BufWriter, Write};
+use std::io::{self, Write};
 use std::path::Path;
 
 use super::WriteError;
@@ -15,11 +15,10 @@ pub(super) fn write_fonts<P: AsRef<Path>>(
     fs: &dyn FileSystem,
 ) -> Result<(), WriteError> {
     let fonts_json_path = expanded_dir.as_ref().join("fonts.json");
-    let fonts_index_file = fs.create_file(&fonts_json_path)?;
-    let mut fonts_index_writer = BufWriter::new(fonts_index_file);
+    let mut fonts_index_file = fs.create_buffered_file(&fonts_json_path)?;
     let fonts_index: Vec<FontDataJson> = fonts.iter().map(FontDataJson::from_font_data).collect();
-    serde_json::to_writer_pretty(&mut fonts_index_writer, &fonts_index)?;
-    fonts_index_writer.flush()?;
+    serde_json::to_writer_pretty(&mut fonts_index_file, &fonts_index)?;
+    fonts_index_file.flush()?;
 
     let fonts_dir = expanded_dir.as_ref().join("fonts");
     fs.create_dir_all(&fonts_dir)?;

--- a/src/vpx/expanded/gameitems.rs
+++ b/src/vpx/expanded/gameitems.rs
@@ -6,7 +6,7 @@ use log::info;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 use std::collections::HashSet;
-use std::io::{self, BufWriter, Write};
+use std::io::{self, Write};
 use std::path::Path;
 use tracing::instrument;
 
@@ -98,10 +98,9 @@ pub(super) fn write_gameitems<P: AsRef<Path>>(
     }
 
     let gameitems_index_path = expanded_dir.as_ref().join("gameitems.json");
-    let gameitems_index_file = fs.create_file(&gameitems_index_path)?;
-    let mut gameitems_index_writer = BufWriter::new(gameitems_index_file);
-    serde_json::to_writer_pretty(&mut gameitems_index_writer, &files)?;
-    gameitems_index_writer.flush()?;
+    let mut gameitems_index_file = fs.create_buffered_file(&gameitems_index_path)?;
+    serde_json::to_writer_pretty(&mut gameitems_index_file, &files)?;
+    gameitems_index_file.flush()?;
 
     let gameitems_ref = gameitems;
     let gameitems_dir_clone = gameitems_dir.clone();

--- a/src/vpx/expanded/images.rs
+++ b/src/vpx/expanded/images.rs
@@ -6,7 +6,7 @@ use crate::vpx::lzw::to_lzw_blocks;
 use log::{debug, info, warn};
 use std::collections::HashSet;
 use std::ffi::OsStr;
-use std::io::{self, BufRead, BufWriter, Seek, Write};
+use std::io::{self, BufRead, Seek, Write};
 use std::path::Path;
 
 use super::WriteError;
@@ -26,8 +26,7 @@ pub(super) fn write_images<P: AsRef<Path>>(
     info!("Starting image processing - total images: {}", images.len());
 
     let images_index_path = expanded_dir.as_ref().join("images.json");
-    let images_index_file = fs.create_file(&images_index_path)?;
-    let mut images_index_writer = BufWriter::new(images_index_file);
+    let mut images_index_file = fs.create_buffered_file(&images_index_path)?;
     let mut image_names_lower: HashSet<String> = HashSet::new();
     let mut image_names_dupe_counter = 0;
     let mut json_images = Vec::with_capacity(images.len());
@@ -111,8 +110,8 @@ pub(super) fn write_images<P: AsRef<Path>>(
         })
         .collect();
     let images_list = images_list?;
-    serde_json::to_writer_pretty(&mut images_index_writer, &json_images)?;
-    images_index_writer.flush()?;
+    serde_json::to_writer_pretty(&mut images_index_file, &json_images)?;
+    images_index_file.flush()?;
 
     let images_dir = expanded_dir.as_ref().join("images");
     fs.create_dir_all(&images_dir)?;

--- a/src/vpx/expanded/materials.rs
+++ b/src/vpx/expanded/materials.rs
@@ -5,7 +5,7 @@ use crate::vpx::material::{
     Material, MaterialJson, SaveMaterial, SaveMaterialJson, SavePhysicsMaterial,
     SavePhysicsMaterialJson,
 };
-use std::io::{self, BufWriter, Write};
+use std::io::{self, Write};
 use std::path::Path;
 
 use super::WriteError;
@@ -16,12 +16,11 @@ pub(super) fn write_materials<P: AsRef<Path>>(
     fs: &dyn FileSystem,
 ) -> Result<(), WriteError> {
     let materials_path = expanded_dir.as_ref().join("materials.json");
-    let materials_file = fs.create_file(&materials_path)?;
-    let mut materials_writer = BufWriter::new(materials_file);
+    let mut materials_file = fs.create_buffered_file(&materials_path)?;
     let materials_index: Vec<MaterialJson> =
         materials.iter().map(MaterialJson::from_material).collect();
-    serde_json::to_writer_pretty(&mut materials_writer, &materials_index)?;
-    materials_writer.flush()?;
+    serde_json::to_writer_pretty(&mut materials_file, &materials_index)?;
+    materials_file.flush()?;
     Ok(())
 }
 
@@ -33,7 +32,7 @@ pub(super) fn read_materials<P: AsRef<Path>>(
     if !fs.exists(&materials_path) {
         return Ok(None);
     }
-    let mut materials_file = fs.open_file(&materials_path)?;
+    let mut materials_file = fs.open_buffered_file(&materials_path)?;
     let materials_index: Vec<MaterialJson> = serde_json::from_reader(&mut materials_file)?;
     let materials: Vec<Material> = materials_index
         .into_iter()
@@ -58,14 +57,13 @@ fn write_old_materials<P: AsRef<Path>>(
     fs: &dyn FileSystem,
 ) -> Result<(), WriteError> {
     let materials_path = expanded_dir.as_ref().join("materials-old.json");
-    let materials_file = fs.create_file(&materials_path)?;
-    let mut materials_writer = BufWriter::new(materials_file);
+    let mut materials_file = fs.create_buffered_file(&materials_path)?;
     let materials_index: Vec<SaveMaterialJson> = materials_old
         .iter()
         .map(SaveMaterialJson::from_save_material)
         .collect();
-    serde_json::to_writer_pretty(&mut materials_writer, &materials_index)?;
-    materials_writer.flush()?;
+    serde_json::to_writer_pretty(&mut materials_file, &materials_index)?;
+    materials_file.flush()?;
     Ok(())
 }
 
@@ -77,7 +75,7 @@ pub(super) fn read_old_materials<P: AsRef<Path>>(
     if !fs.exists(&materials_path) {
         return Ok(None);
     }
-    let mut materials_file = fs.open_file(&materials_path)?;
+    let mut materials_file = fs.open_buffered_file(&materials_path)?;
     let materials_index: Vec<SaveMaterialJson> = serde_json::from_reader(&mut materials_file)?;
     let materials: Vec<SaveMaterial> = materials_index
         .into_iter()
@@ -93,14 +91,13 @@ fn write_old_materials_physics<P: AsRef<Path>>(
 ) -> Result<(), WriteError> {
     if let Some(materials) = materials_physics_old {
         let materials_path = expanded_dir.as_ref().join("materials-physics-old.json");
-        let materials_file = fs.create_file(&materials_path)?;
-        let mut materials_writer = BufWriter::new(materials_file);
+        let mut materials_file = fs.create_buffered_file(&materials_path)?;
         let materials_index: Vec<SavePhysicsMaterialJson> = materials
             .iter()
             .map(SavePhysicsMaterialJson::from_save_physics_material)
             .collect();
-        serde_json::to_writer_pretty(&mut materials_writer, &materials_index)?;
-        materials_writer.flush()?;
+        serde_json::to_writer_pretty(&mut materials_file, &materials_index)?;
+        materials_file.flush()?;
     }
     Ok(())
 }
@@ -113,7 +110,7 @@ pub(super) fn read_old_materials_physics<P: AsRef<Path>>(
     if !fs.exists(&materials_path) {
         return Ok(None);
     }
-    let mut materials_file = fs.open_file(&materials_path)?;
+    let mut materials_file = fs.open_buffered_file(&materials_path)?;
     let materials_index: Vec<SavePhysicsMaterialJson> =
         serde_json::from_reader(&mut materials_file)?;
     let materials: Vec<SavePhysicsMaterial> = materials_index

--- a/src/vpx/expanded/metadata.rs
+++ b/src/vpx/expanded/metadata.rs
@@ -9,7 +9,7 @@ use crate::vpx::renderprobe::{RenderProbeJson, RenderProbeWithGarbage};
 use crate::vpx::tableinfo::TableInfo;
 use log::info;
 use serde_json::Value;
-use std::io::{self, BufWriter, Write};
+use std::io::{self, Write};
 use std::path::Path;
 
 use super::WriteError;
@@ -21,11 +21,10 @@ pub(super) fn write_game_data<P: AsRef<Path>>(
     fs: &dyn FileSystem,
 ) -> Result<(), WriteError> {
     let game_data_path = expanded_dir.as_ref().join("gamedata.json");
-    let game_data_file = fs.create_file(&game_data_path)?;
-    let mut game_data_writer = BufWriter::new(game_data_file);
+    let mut game_data_file = fs.create_buffered_file(&game_data_path)?;
     let json = GameDataJson::from_game_data(gamedata);
-    serde_json::to_writer_pretty(&mut game_data_writer, &json)?;
-    game_data_writer.flush()?;
+    serde_json::to_writer_pretty(&mut game_data_file, &json)?;
+    game_data_file.flush()?;
     let script_path = expanded_dir.as_ref().join("script.vbs");
     let mut script_file = fs.create_file(&script_path)?;
     let script_bytes: Vec<u8> = gamedata.code.clone().into();
@@ -59,11 +58,10 @@ pub(super) fn write_info<P: AsRef<Path>>(
     fs: &dyn FileSystem,
 ) -> Result<(), WriteError> {
     let json_path = expanded_dir.as_ref().join("info.json");
-    let json_file = fs.create_file(&json_path)?;
-    let mut json_writer = BufWriter::new(json_file);
+    let mut json_file = fs.create_buffered_file(&json_path)?;
     let info = info_to_json(info, custominfotags);
-    serde_json::to_writer_pretty(&mut json_writer, &info)?;
-    json_writer.flush()?;
+    serde_json::to_writer_pretty(&mut json_file, &info)?;
+    json_file.flush()?;
     Ok(())
 }
 
@@ -87,11 +85,10 @@ pub(super) fn write_collections<P: AsRef<Path>>(
     fs: &dyn FileSystem,
 ) -> Result<(), WriteError> {
     let collections_json_path = expanded_dir.as_ref().join("collections.json");
-    let collections_json_file = fs.create_file(&collections_json_path)?;
-    let mut collections_json_writer = BufWriter::new(collections_json_file);
+    let mut collections_json_file = fs.create_buffered_file(&collections_json_path)?;
     let json_collections = collections_json(collections);
-    serde_json::to_writer_pretty(&mut collections_json_writer, &json_collections)?;
-    collections_json_writer.flush()?;
+    serde_json::to_writer_pretty(&mut collections_json_file, &json_collections)?;
+    collections_json_file.flush()?;
     Ok(())
 }
 
@@ -116,14 +113,13 @@ pub(super) fn write_renderprobes<P: AsRef<Path>>(
 ) -> Result<(), WriteError> {
     if let Some(renderprobes) = render_probes {
         let renderprobes_path = expanded_dir.as_ref().join("renderprobes.json");
-        let renderprobes_file = fs.create_file(&renderprobes_path)?;
-        let mut renderprobes_writer = BufWriter::new(renderprobes_file);
+        let mut renderprobes_file = fs.create_buffered_file(&renderprobes_path)?;
         let renderprobes_index: Vec<RenderProbeJson> = renderprobes
             .iter()
             .map(RenderProbeJson::from_renderprobe)
             .collect();
-        serde_json::to_writer_pretty(&mut renderprobes_writer, &renderprobes_index)?;
-        renderprobes_writer.flush()?;
+        serde_json::to_writer_pretty(&mut renderprobes_file, &renderprobes_index)?;
+        renderprobes_file.flush()?;
     }
     Ok(())
 }

--- a/src/vpx/expanded/sounds.rs
+++ b/src/vpx/expanded/sounds.rs
@@ -4,7 +4,7 @@ use crate::filesystem::FileSystem;
 use crate::vpx::sound::{SoundData, SoundDataJson, read_sound, write_sound};
 use log::info;
 use std::collections::HashSet;
-use std::io::{self, BufWriter, Write};
+use std::io::{self, Write};
 use std::path::Path;
 
 use super::WriteError;
@@ -16,8 +16,7 @@ pub(super) fn write_sounds<P: AsRef<Path>>(
     fs: &dyn FileSystem,
 ) -> Result<(), WriteError> {
     let sounds_index_path = expanded_dir.as_ref().join("sounds.json");
-    let sounds_index_file = fs.create_file(&sounds_index_path)?;
-    let mut sounds_index_writer = BufWriter::new(sounds_index_file);
+    let mut sounds_index_file = fs.create_buffered_file(&sounds_index_path)?;
     let mut sound_names_lower: HashSet<String> = HashSet::new();
     let mut sound_names_dupe_counter = 0;
     let mut json_sounds = Vec::with_capacity(sounds.len());
@@ -51,8 +50,8 @@ pub(super) fn write_sounds<P: AsRef<Path>>(
             (file_name, sound)
         })
         .collect();
-    serde_json::to_writer_pretty(&mut sounds_index_writer, &json_sounds)?;
-    sounds_index_writer.flush()?;
+    serde_json::to_writer_pretty(&mut sounds_index_file, &json_sounds)?;
+    sounds_index_file.flush()?;
 
     let sounds_dir = expanded_dir.as_ref().join("sounds");
     fs.create_dir_all(&sounds_dir)?;

--- a/src/vpx/expanded/util.rs
+++ b/src/vpx/expanded/util.rs
@@ -26,7 +26,7 @@ where
             format!("JSON file not found: {}", path.display()),
         ));
     }
-    let mut json_file = fs.open_file(path)?;
+    let mut json_file = fs.open_buffered_file(path)?;
     serde_json::from_reader(&mut json_file).map_err(|e| {
         io::Error::other(format!(
             "Failed to parse/read json {}: {}",


### PR DESCRIPTION
## Summary

Follow-up to #308. Moves the BufWriter/BufReader policy out of every call site and into the `FileSystem` trait, where each impl can answer for itself whether extra buffering is warranted.

- Adds default methods `FileSystem::create_buffered_file` and `open_buffered_file`. Defaults wrap `create_file` / `open_file` in `BufWriter` / `BufReader`.
- `MemoryFileSystem` overrides both to delegate to the raw methods - its writer is `Vec<u8>`-backed and its reader is a `Cursor<Vec<u8>>`, both already byte-buffered. The extra layer was harmless but pointless.
- Collapses the call-site plumbing introduced in #308 (`BufWriter::new(fs.create_file(...))` -> `fs.create_buffered_file(...)`).

## Read side too

While at it, this PR fixes the symmetric read-side gap that #308 didn't touch:

- `src/vpx/expanded/util.rs::read_json` (the central JSON reader used by sounds, fonts, info, gamedata, collections, renderprobes, gameitems, images) now uses `open_buffered_file`.
- The three direct `open_file` + `serde_json::from_reader` sites in `src/vpx/expanded/materials.rs` (current, legacy, legacy-physics) too.

That gives the same NAS-friendly behaviour on read that #308 gave on write. `serde_json::from_reader` issues many small reads per token; unbuffered on a network mount is slow for the same reasons unbuffered writes were.

## Out of scope (still)

- `read_obj_from_reader<R: BufRead>` already requires `BufRead` at the type level, and all callers wrap in `BufReader` before calling.
- `read_glb_from_reader` is called on `Cursor<Vec<u8>>`, in-memory.
- CompoundFile (`cfb`) reads/writes - the trait requires `Read + Write + Seek`, so external buffering wouldn't fit.

## Notes

- Public API addition only: existing `create_file` / `open_file` callers (none in this PR, but downstream) keep working unchanged.
- `flush()?` is still called explicitly at write sites. `Drop`-time flush errors are swallowed regardless of how the writer was constructed - there's no way around that without a typed wrapper, which would defeat the `dyn Write` erasure.

## Test plan

- [x] `cargo build` - clean
- [x] `cargo clippy --all-targets` - clean
- [x] `cargo test --lib` - all 354 tests pass