### PR TITLE
ci: disable rust-cache cache-bin to fix macOS build

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,12 @@ jobs:
           toolchain: stable
           components: rustfmt, clippy
       - uses: Swatinem/rust-cache@v2.9.1
+        with:
+          # Work around https://github.com/Swatinem/rust-cache/issues/341 -
+          # cache-bin: true collides with the rustup proxies on the new GitHub
+          # macOS runner image, making `cargo` dispatch as `rustup-init` after
+          # cache restore.
+          cache-bin: false
       - name: Build
         run: cargo build --verbose
       - name: Run tests


### PR DESCRIPTION
## Summary

Build matrix's macOS job is failing because the new GitHub macOS runner image (actions/runner-images#14037) interacts badly with `Swatinem/rust-cache`'s `cache-bin: true` default. After cache restore, \`\$CARGO_HOME/bin/cargo\` ends up resolving to \`rustup-init\`, so \`cargo build\` dispatches as the installer:

\`\`\`
error: unexpected argument 'build' found
Usage: rustup-init[EXE] [OPTIONS]
\`\`\`

This is tracked upstream: [Swatinem/rust-cache#341](https://github.com/Swatinem/rust-cache/issues/341). Reporter confirms `cache-bin: false` is the workaround.

## What this does

Adds \`cache-bin: false\` to the \`Swatinem/rust-cache\` step in the build matrix. The toolchain proxies installed by \`dtolnay/rust-toolchain\` then survive the cache round-trip.

The two wasm jobs are left alone:
- They run on \`ubuntu-latest\`, not affected by the macOS image change.
- They legitimately benefit from \`cache-bin: true\` because they run \`cargo install wasmtime-cli\` / \`cargo install wasm-bindgen-cli\`. Caching those bins saves real time.

## Cache eviction note

The already-poisoned macOS cache (key prefix \`v0-rust-build-Darwin-x64-...\`) will linger until evicted or aged out (7-day GH Actions cache TTL). With \`cache-bin: false\` the new restore won't try to bring back \`\$CARGO_HOME/bin\` (rust-cache narrows both save and restore paths based on the flag), so the next run should be clean. If anything still misbehaves, manually delete the macOS cache entry via Settings -> Actions -> Caches.

## Test plan

- [ ] CI passes on this PR (all three platforms reach \`cargo build\` and \`cargo test\`).