### PR TITLE
chore: release v0.26.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.3](https://github.com/francisdb/vpin/compare/v0.26.2...v0.26.3) - 2026-05-14
+
+### Added
+
+- *(obj)* include plunger meshes by default ([#316](https://github.com/francisdb/vpin/pull/316))
+
+### Fixed
+
+- *(mesh)* match vpinball plunger geometry ([#314](https://github.com/francisdb/vpin/pull/314))
+
 ## [0.26.2](https://github.com/francisdb/vpin/compare/v0.26.1...v0.26.2) - 2026-05-14
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vpin"
-version = "0.26.2"
+version = "0.26.3"
 edition = "2024"
 description = "Rust library for working with Visual Pinball VPX files"
 repository = "https://github.com/francisdb/vpin"


### PR DESCRIPTION



## 🤖 New release

* `vpin`: 0.26.2 -> 0.26.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.3](https://github.com/francisdb/vpin/compare/v0.26.2...v0.26.3) - 2026-05-14

### Added

- *(obj)* include plunger meshes by default ([#316](https://github.com/francisdb/vpin/pull/316))

### Fixed

- *(mesh)* match vpinball plunger geometry ([#314](https://github.com/francisdb/vpin/pull/314))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).