### PR TITLE
chore: release v0.26.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.4](https://github.com/francisdb/vpin/compare/v0.26.3...v0.26.4) - 2026-05-30
+
+### Added
+
+- make the mesh module public ([#319](https://github.com/francisdb/vpin/pull/319))
+
+### Other
+
+- *(deps)* update weezl requirement from 0.1.12 to 0.2.1 ([#317](https://github.com/francisdb/vpin/pull/317))
+
 ## [0.26.3](https://github.com/francisdb/vpin/compare/v0.26.2...v0.26.3) - 2026-05-14
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vpin"
-version = "0.26.3"
+version = "0.26.4"
 edition = "2024"
 description = "Rust library for working with Visual Pinball VPX files"
 repository = "https://github.com/francisdb/vpin"


### PR DESCRIPTION



## 🤖 New release

* `vpin`: 0.26.3 -> 0.26.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.4](https://github.com/francisdb/vpin/compare/v0.26.3...v0.26.4) - 2026-05-30

### Added

- make the mesh module public ([#319](https://github.com/francisdb/vpin/pull/319))

### Other

- *(deps)* update weezl requirement from 0.1.12 to 0.2.1 ([#317](https://github.com/francisdb/vpin/pull/317))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).