### PR TITLE
feat: expose spinner mesh module

### DIFF
--- a/src/vpx/mesh/mod.rs
+++ b/src/vpx/mesh/mod.rs
@@ -15,7 +15,7 @@ pub(crate) mod playfields;
 pub(crate) mod plungers;
 pub(crate) mod ramps;
 pub(crate) mod rubbers;
-pub(crate) mod spinners;
+pub mod spinners;
 pub(crate) mod triggers;
 pub(crate) mod walls;
 


### PR DESCRIPTION
Make the spinner mesh module public so external consumers can reuse the plate mesh data (build_spinner_meshes, SPINNER_PLATE_MESH, SPINNER_PLATE_INDICES).