### PR TITLE
chore: release v0.26.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.5](https://github.com/francisdb/vpin/compare/v0.26.4...v0.26.5) - 2026-06-02
+
+### Added
+
+- expose spinner mesh module ([#320](https://github.com/francisdb/vpin/pull/320))
+
 ## [0.26.4](https://github.com/francisdb/vpin/compare/v0.26.3...v0.26.4) - 2026-05-30
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vpin"
-version = "0.26.4"
+version = "0.26.5"
 edition = "2024"
 description = "Rust library for working with Visual Pinball VPX files"
 repository = "https://github.com/francisdb/vpin"


### PR DESCRIPTION



## 🤖 New release

* `vpin`: 0.26.4 -> 0.26.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.5](https://github.com/francisdb/vpin/compare/v0.26.4...v0.26.5) - 2026-06-02

### Added

- expose spinner mesh module ([#320](https://github.com/francisdb/vpin/pull/320))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).