### PR TITLE
chore: release v0.26.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.6](https://github.com/francisdb/vpin/compare/v0.26.5...v0.26.6) - 2026-06-10
+
+### Fixed
+
+- make internal_name optional when reading sounds.json ([#322](https://github.com/francisdb/vpin/pull/322))
+
 ## [0.26.5](https://github.com/francisdb/vpin/compare/v0.26.4...v0.26.5) - 2026-06-02
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vpin"
-version = "0.26.5"
+version = "0.26.6"
 edition = "2024"
 description = "Rust library for working with Visual Pinball VPX files"
 repository = "https://github.com/francisdb/vpin"


### PR DESCRIPTION



## 🤖 New release

* `vpin`: 0.26.5 -> 0.26.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.6](https://github.com/francisdb/vpin/compare/v0.26.5...v0.26.6) - 2026-06-10

### Fixed

- make internal_name optional when reading sounds.json ([#322](https://github.com/francisdb/vpin/pull/322))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).