### PR TITLE
chore: release v0.26.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.7](https://github.com/francisdb/vpin/compare/v0.26.6...v0.26.7) - 2026-06-10
+
+### Fixed
+
+- preserve vertex bytes that obj text cannot represent ([#326](https://github.com/francisdb/vpin/pull/326))
+- make the obj V texture coordinate flip lossless ([#324](https://github.com/francisdb/vpin/pull/324))
+
+### Other
+
+- name the byte preservation decision
+- start the flipped V precision search at an estimate
+
 ## [0.26.6](https://github.com/francisdb/vpin/compare/v0.26.5...v0.26.6) - 2026-06-10
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vpin"
-version = "0.26.6"
+version = "0.26.7"
 edition = "2024"
 description = "Rust library for working with Visual Pinball VPX files"
 repository = "https://github.com/francisdb/vpin"


### PR DESCRIPTION



## 🤖 New release

* `vpin`: 0.26.6 -> 0.26.7

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.7](https://github.com/francisdb/vpin/compare/v0.26.6...v0.26.7) - 2026-06-10

### Fixed

- preserve vertex bytes that obj text cannot represent ([#326](https://github.com/francisdb/vpin/pull/326))
- make the obj V texture coordinate flip lossless ([#324](https://github.com/francisdb/vpin/pull/324))

### Other

- name the byte preservation decision
- start the flipped V precision search at an estimate
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).