### PR TITLE
chore: release v0.26.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.8](https://github.com/francisdb/vpin/compare/v0.26.7...v0.26.8) - 2026-06-11
+
+### Added
+
+- make material physics properties public
+
 ## [0.26.7](https://github.com/francisdb/vpin/compare/v0.26.6...v0.26.7) - 2026-06-10
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vpin"
-version = "0.26.7"
+version = "0.26.8"
 edition = "2024"
 description = "Rust library for working with Visual Pinball VPX files"
 repository = "https://github.com/francisdb/vpin"


### PR DESCRIPTION



## 🤖 New release

* `vpin`: 0.26.7 -> 0.26.8

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.8](https://github.com/francisdb/vpin/compare/v0.26.7...v0.26.8) - 2026-06-11

### Added

- make material physics properties public
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).