### PR TITLE
feat: make the gameitem mesh modules public

### DIFF
--- a/src/vpx/mesh/mod.rs
+++ b/src/vpx/mesh/mod.rs
@@ -1,22 +1,22 @@
 //! Mesh generation
 
-pub(crate) mod balls;
+pub mod balls;
 pub(crate) mod builtin_primitive;
-pub(crate) mod bumpers;
+pub mod bumpers;
 pub(crate) mod decals;
 pub(crate) mod flashers;
-pub(crate) mod flippers;
-pub(crate) mod gates;
-pub(crate) mod hittargets;
-pub(crate) mod kickers;
-pub(crate) mod lights;
+pub mod flippers;
+pub mod gates;
+pub mod hittargets;
+pub mod kickers;
+pub mod lights;
 pub(crate) mod mesh_validation;
 pub(crate) mod playfields;
-pub(crate) mod plungers;
-pub(crate) mod ramps;
+pub mod plungers;
+pub mod ramps;
 pub(crate) mod rubbers;
 pub mod spinners;
-pub(crate) mod triggers;
+pub mod triggers;
 pub(crate) mod walls;
 
 /// Static detail level used by VPinball to approximate ramps and rubbers for physics/collision code.


### PR DESCRIPTION
Downstream renderers need the built-in gameitem meshes (flipper bats with their UV atlas, kicker cups, trigger wires, gate brackets, ramp wires...) to draw faithful top-down projections, the same way the spinner plate mesh is already consumed through the public spinners module. Expose the remaining mesh modules; their builder APIs were already written as if public (doc comments, validated inputs).