### PR TITLE
fix: handle unknown GateType values instead of panicking

### DIFF
--- a/src/vpx/gameitem/gate.rs
+++ b/src/vpx/gameitem/gate.rs
@@ -8,10 +8,23 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[derive(Debug, PartialEq, Clone)]
 #[cfg_attr(test, derive(fake::Dummy))]
 pub enum GateType {
-    WireW = 1,
-    WireRectangle = 2,
-    Plate = 3,
-    LongPlate = 4,
+    WireW,
+    WireRectangle,
+    Plate,
+    LongPlate,
+    /// Any value outside the known range 1-4, seen as 0 in the wild, for example in
+    /// "Algar (1980)", "Asteroid Annie (1980)", "Fireball II (1981)", "Tri Zone (1979)".
+    ///
+    /// Visual Pinball introduced the gate type (GATY tag) in November 2015
+    /// (svn r2396 / git db10b60b7) but did not initialize `m_type` when loading
+    /// older tables that lacked the tag, while unconditionally writing it on save.
+    /// Tables re-saved with a build from that era thus got uninitialized memory,
+    /// in practice usually 0, persisted as their gate type. Since December 2018
+    /// (svn r3583 / git 8cc5a7a1a) Visual Pinball falls back to `GateWireW` for any
+    /// out-of-range value at load time, but never rewrites the file.
+    ///
+    /// The raw value is kept here so that files round-trip unchanged.
+    Unknown(u32),
 }
 
 impl From<u32> for GateType {
@@ -21,7 +34,7 @@ impl From<u32> for GateType {
             2 => GateType::WireRectangle,
             3 => GateType::Plate,
             4 => GateType::LongPlate,
-            _ => panic!("Unknown GateType: {value}"),
+            other => GateType::Unknown(other),
         }
     }
 }
@@ -33,10 +46,12 @@ impl From<GateType> for u32 {
             GateType::WireRectangle => 2,
             GateType::Plate => 3,
             GateType::LongPlate => 4,
+            GateType::Unknown(value) => value,
         }
     }
 }
 
+/// Serialize to lowercase string, or the raw number for unknown values
 impl Serialize for GateType {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -47,27 +62,57 @@ impl Serialize for GateType {
             GateType::WireRectangle => serializer.serialize_str("wire_rectangle"),
             GateType::Plate => serializer.serialize_str("plate"),
             GateType::LongPlate => serializer.serialize_str("long_plate"),
+            GateType::Unknown(value) => serializer.serialize_u32(*value),
         }
     }
 }
 
+/// Deserialize from lowercase string or number
 impl<'de> Deserialize<'de> for GateType {
     fn deserialize<D>(deserializer: D) -> Result<GateType, D::Error>
     where
         D: Deserializer<'de>,
     {
-        let value = String::deserialize(deserializer)?;
-        let s = value.as_str();
-        match s {
-            "wire_w" => Ok(GateType::WireW),
-            "wire_rectangle" => Ok(GateType::WireRectangle),
-            "plate" => Ok(GateType::Plate),
-            "long_plate" => Ok(GateType::LongPlate),
-            _ => Err(serde::de::Error::unknown_variant(
-                s,
-                &["wire_w", "wire_rectangle", "plate", "long_plate"],
-            )),
+        struct GateTypeVisitor;
+
+        impl serde::de::Visitor<'_> for GateTypeVisitor {
+            type Value = GateType;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a string or number representing a GateType")
+            }
+
+            fn visit_u64<E>(self, value: u64) -> Result<GateType, E>
+            where
+                E: serde::de::Error,
+            {
+                let value = u32::try_from(value).map_err(|_| {
+                    serde::de::Error::invalid_value(
+                        serde::de::Unexpected::Unsigned(value),
+                        &"a number that fits in a u32",
+                    )
+                })?;
+                Ok(GateType::from(value))
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<GateType, E>
+            where
+                E: serde::de::Error,
+            {
+                match value {
+                    "wire_w" => Ok(GateType::WireW),
+                    "wire_rectangle" => Ok(GateType::WireRectangle),
+                    "plate" => Ok(GateType::Plate),
+                    "long_plate" => Ok(GateType::LongPlate),
+                    _ => Err(serde::de::Error::unknown_variant(
+                        value,
+                        &["wire_w", "wire_rectangle", "plate", "long_plate"],
+                    )),
+                }
+            }
         }
+
+        deserializer.deserialize_any(GateTypeVisitor)
     }
 }
 
@@ -482,6 +527,37 @@ mod tests {
         assert_eq!(json, "\"wire_rectangle\"");
         let gate_type_read: GateType = serde_json::from_str(&json).unwrap();
         assert_eq!(gate_type, gate_type_read);
+    }
+
+    #[test]
+    fn test_gate_type_unknown() {
+        // gate type 0 exists in old tables re-saved with 2015-2018 VPX builds,
+        // see https://github.com/francisdb/vpin/issues/334
+        assert_eq!(GateType::from(0u32), GateType::Unknown(0));
+        assert_eq!(u32::from(GateType::Unknown(0)), 0u32);
+        assert_eq!(GateType::from(7u32), GateType::Unknown(7));
+        assert_eq!(u32::from(GateType::Unknown(7)), 7u32);
+    }
+
+    #[test]
+    fn test_gate_type_unknown_json() {
+        let gate_type = GateType::Unknown(0);
+        let json = serde_json::to_string(&gate_type).unwrap();
+        assert_eq!(json, "0");
+        let gate_type_read: GateType = serde_json::from_str(&json).unwrap();
+        assert_eq!(gate_type, gate_type_read);
+    }
+
+    #[test]
+    fn test_write_read_unknown_gate_type() {
+        let gate = Gate {
+            gate_type: Some(GateType::Unknown(0)),
+            ..Default::default()
+        };
+        let mut writer = BiffWriter::new();
+        Gate::biff_write(&gate, &mut writer);
+        let gate_read = Gate::biff_read(&mut BiffReader::new(writer.get_data()));
+        assert_eq!(gate, gate_read);
     }
 
     #[test]

--- a/src/vpx/gameitem/gate.rs
+++ b/src/vpx/gameitem/gate.rs
@@ -27,6 +27,16 @@ pub enum GateType {
     Unknown(u32),
 }
 
+impl GateType {
+    /// The gate type to fall back to when the stored value is
+    /// [`GateType::Unknown`] or the `GATY` tag is missing altogether.
+    ///
+    /// Visual Pinball coerces any out-of-range gate type to `GateWireW` at load
+    /// time (since svn r3583 / git 8cc5a7a1a) and also uses it as the default
+    /// for tables predating the `GATY` tag.
+    pub const UNKNOWN_FALLBACK: GateType = GateType::WireW;
+}
+
 impl From<u32> for GateType {
     fn from(value: u32) -> Self {
         match value {

--- a/src/vpx/mesh/gates/mod.rs
+++ b/src/vpx/mesh/gates/mod.rs
@@ -48,9 +48,7 @@ fn get_mesh_for_type(gate_type: &GateType) -> (&'static [Vertex3dNoTex2], &'stat
         GateType::WireRectangle => (&GATE_WIRE_RECTANGLE_MESH, &GATE_WIRE_RECTANGLE_INDICES),
         GateType::Plate => (&GATE_PLATE_MESH, &GATE_PLATE_INDICES),
         GateType::LongPlate => (&GATE_LONG_PLATE_MESH, &GATE_LONG_PLATE_INDICES),
-        // VPinball falls back to the wire W mesh for out-of-range gate types,
-        // see Gate load code in vpinball src/parts/gate.cpp
-        GateType::Unknown(_) => (&GATE_WIRE_MESH, &GATE_WIRE_INDICES),
+        GateType::Unknown(_) => get_mesh_for_type(&GateType::UNKNOWN_FALLBACK),
     }
 }
 
@@ -192,7 +190,10 @@ pub fn build_gate_meshes(gate: &Gate) -> Option<GateMeshes> {
 /// runtime visibility flag) - it only filters at the table level via
 /// `m_uiVisible`. The OBJ exporter uses this variant to match.
 pub(crate) fn build_gate_meshes_unchecked(gate: &Gate) -> Option<GateMeshes> {
-    let gate_type = gate.gate_type.as_ref().unwrap_or(&GateType::WireW);
+    let gate_type = gate
+        .gate_type
+        .as_ref()
+        .unwrap_or(&GateType::UNKNOWN_FALLBACK);
     let (mesh, indices) = get_mesh_for_type(gate_type);
 
     Some(GateMeshes {

--- a/src/vpx/mesh/gates/mod.rs
+++ b/src/vpx/mesh/gates/mod.rs
@@ -48,6 +48,9 @@ fn get_mesh_for_type(gate_type: &GateType) -> (&'static [Vertex3dNoTex2], &'stat
         GateType::WireRectangle => (&GATE_WIRE_RECTANGLE_MESH, &GATE_WIRE_RECTANGLE_INDICES),
         GateType::Plate => (&GATE_PLATE_MESH, &GATE_PLATE_INDICES),
         GateType::LongPlate => (&GATE_LONG_PLATE_MESH, &GATE_LONG_PLATE_INDICES),
+        // VPinball falls back to the wire W mesh for out-of-range gate types,
+        // see Gate load code in vpinball src/parts/gate.cpp
+        GateType::Unknown(_) => (&GATE_WIRE_MESH, &GATE_WIRE_INDICES),
     }
 }
 


### PR DESCRIPTION
## Summary

`GateType::from(u32)` panicked on any value outside 1-4, aborting the read of real-world tables that contain gate type 0 (e.g. Algar (1980), Asteroid Annie (1980), Fireball II (1981), Lethal Weapon 3 (1992), Tri Zone (1979)).

This adds a `GateType::Unknown(u32)` catch-all variant that preserves the raw value so such files can be read and round-tripped byte-exact.

## Where the 0 comes from (vpinball history)

- Visual Pinball introduced the gate type (`GATY` tag) in November 2015 (svn r2396 / git `db10b60b7`, "more gate shapes added"), but did not initialize `m_type` when loading older tables that lacked the tag, while unconditionally writing it on save. Tables re-saved with a build from that era got uninitialized memory, in practice usually 0, persisted as their gate type.
- Since December 2018 (svn r3583 / git `8cc5a7a1a`) Visual Pinball falls back to `GateWireW` for any out-of-range value at load time, but never rewrites the file, so the 0 values are still out there.

## Changes

- `GateType::Unknown(u32)` variant with documentation of the above; `From<u32>` no longer panics. Explicit discriminants were dropped since Rust forbids them on enums with data-carrying variants; the `From` impls carry the numeric mapping.
- JSON serde: known variants stay lowercase strings, `Unknown(v)` serializes as the raw number; the deserializer accepts numbers as well (same visitor pattern as `PlungerType`).
- Mesh generation maps `Unknown(_)` to the wire W mesh, matching Visual Pinball's runtime fallback.
- Tests for the conversions, JSON round-trip, and BIFF write/read round-trip with `Unknown(0)`.

Fixes #334