### PR TITLE
ci: install wasmtime and wasm-bindgen as prebuilt binaries

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,8 +53,11 @@ jobs:
           toolchain: stable
           targets: wasm32-wasip1
       - uses: Swatinem/rust-cache@v2.9.1
-      - name: Install wasmtime-cli
-        run: cargo install wasmtime-cli
+      # Downloads a prebuilt binary, building wasmtime from source takes over 5 minutes
+      - name: Install wasmtime
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasmtime
       - name: Run WASM tests
         run: cargo test --target wasm32-wasip1
 
@@ -69,7 +72,9 @@ jobs:
           toolchain: stable
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2.9.1
-      - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli
+      - name: Install wasm-bindgen
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-bindgen
       - name: Run WASM tests
         run: cargo test --target wasm32-unknown-unknown --features wasm

--- a/README.md
+++ b/README.md
@@ -120,9 +120,13 @@ cargo test --release -- --ignored --nocapture
 ```bash
 # Install the target and wasmtime (do this only once)
 rustup target add wasm32-wasip1
-# Building wasmtime from source takes over 5 minutes, prefer a prebuilt binary,
-# see https://docs.wasmtime.dev/cli-install.html or your package manager
+
+# Recommended, installs a prebuilt binary in seconds.
+# See https://docs.wasmtime.dev/cli-install.html for other options like your package manager
 curl https://wasmtime.dev/install.sh -sSf | bash
+
+# Alternative, builds wasmtime from source which takes over 5 minutes
+cargo install wasmtime-cli
 
 # Run tests
 cargo test --target wasm32-wasip1 --features wasm

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 [![Docs.rs](https://docs.rs/vpin/badge.svg)](https://docs.rs/vpin)
 [![npm](https://img.shields.io/npm/v/@francisdb/vpin-wasm.svg)](https://www.npmjs.com/package/@francisdb/vpin-wasm)
 
-Rust library for working with Visual Pinball VPX files. Also available on npm
-as a WASM package: [`@francisdb/vpin-wasm`](https://www.npmjs.com/package/@francisdb/vpin-wasm).
+Rust library for working with Visual Pinball VPX files. Also available on npm as a WASM package: [
+`@francisdb/vpin-wasm`](https://www.npmjs.com/package/@francisdb/vpin-wasm).
 
 Join [#vpxtool on "Virtual Pinball Chat" discord](https://discord.gg/eYsvyMu8) for support and questions.
 
@@ -108,8 +108,8 @@ https://github.com/jsm174/vpx-editor
 
 ## Running the integration tests
 
-We expect a folder `~/vpinball/tables` to exist that contains a lot of `vpx` files. The tests will
-recursively search for these files and run the tests on them.
+We expect a folder `~/vpinball/tables` to exist that contains a lot of `vpx` files. The tests will recursively search
+for these files and run the tests on them.
 
 ```bash
 cargo test --release -- --ignored --nocapture
@@ -120,7 +120,9 @@ cargo test --release -- --ignored --nocapture
 ```bash
 # Install the target and wasmtime (do this only once)
 rustup target add wasm32-wasip1
-cargo install wasmtime-cli
+# Building wasmtime from source takes over 5 minutes, prefer a prebuilt binary,
+# see https://docs.wasmtime.dev/cli-install.html or your package manager
+curl https://wasmtime.dev/install.sh -sSf | bash
 
 # Run tests
 cargo test --target wasm32-wasip1 --features wasm


### PR DESCRIPTION
`cargo install wasmtime-cli` builds a JIT compiler and all of cranelift from source on every run. Measured on the last four runs of the `wasm32-wasip1` job on main:

| run | Install wasmtime-cli |
|---|---|
| 30245484921 | 389s |
| 30245378348 | 391s |
| 29918461032 | 287s |
| 29918431399 | 383s |

Consistently 5 to 6.5 minutes, so the `rust-cache` bin cache is never surviving for it. For contrast, the `Install wasm-bindgen-cli` step in the sibling job restores in **1s**.

`taiki-e/install-action` pulls the prebuilt binaries from the upstream GitHub releases into `$CARGO_HOME/bin`, which is exactly where the runners configured in `.cargo/config.toml` look for them:

```toml
[target.wasm32-wasip1]
runner = "wasmtime"

[target.wasm32-unknown-unknown]
runner = "wasm-bindgen-test-runner"
```

Switched `wasm-bindgen` over as well so both jobs work the same way and neither can fall back to a source build when the bin cache misses.

## Result on this branch

```
wasm32-wasip1 / Install wasmtime: 1s          (was 389s)
wasm32-wasip1 / Run WASM tests: 84s
wasm32-unknown-unknown / Install wasm-bindgen: 0s
wasm32-unknown-unknown / Run WASM tests: 114s
```

Both wasm jobs pass.

The README now lists the prebuilt install as the recommended option and keeps `cargo install wasmtime-cli` as an alternative, so contributors do not pay the same 5 minutes by default.

## Not done here

Versions are left unpinned, same as the current `cargo install` behaviour. Worth considering separately: `cargo install wasm-bindgen-cli` grabs the *latest* CLI while `Cargo.toml` pins `wasm-bindgen = "0.2.108"`, and wasm-bindgen errors out when the CLI and crate versions diverge, so that job can break on an unrelated upstream release. `taiki-e/install-action` supports `tool: wasm-bindgen@0.2.108` if you want to close that off.
