### PR TITLE
ci: resolve the wasm-bindgen cli version from cargo

### DIFF
--- a/.github/workflows/publish-wasm.yml
+++ b/.github/workflows/publish-wasm.yml
@@ -27,8 +27,19 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2.9.1
 
-      - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli
+      # wasm-bindgen refuses to run when the cli and the crate versions diverge, so resolve
+      # the version from cargo instead of hardcoding it here
+      - name: Resolve wasm-bindgen version
+        id: wasm-bindgen
+        run: |
+          version=$(cargo metadata --format-version 1 --features wasm \
+            | jq -r '.packages[] | select(.name=="wasm-bindgen") | .version')
+          echo "Using wasm-bindgen $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Install wasm-bindgen
+        uses: taiki-e/install-action@v2
+        with:
+          tool: wasm-bindgen@${{ steps.wasm-bindgen.outputs.version }}
 
       - name: Build WASM
         run: cargo build --release --target wasm32-unknown-unknown --features wasm --no-default-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,9 +72,18 @@ jobs:
           toolchain: stable
           targets: wasm32-unknown-unknown
       - uses: Swatinem/rust-cache@v2.9.1
+      # wasm-bindgen refuses to run when the cli and the crate versions diverge, so resolve
+      # the version from cargo instead of hardcoding it here
+      - name: Resolve wasm-bindgen version
+        id: wasm-bindgen
+        run: |
+          version=$(cargo metadata --format-version 1 --features wasm \
+            | jq -r '.packages[] | select(.name=="wasm-bindgen") | .version')
+          echo "Using wasm-bindgen $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Install wasm-bindgen
         uses: taiki-e/install-action@v2
         with:
-          tool: wasm-bindgen
+          tool: wasm-bindgen@${{ steps.wasm-bindgen.outputs.version }}
       - name: Run WASM tests
         run: cargo test --target wasm32-unknown-unknown --features wasm


### PR DESCRIPTION
Follow up to #342.

wasm-bindgen refuses to run when the cli and the crate schema versions diverge, and installing the latest cli leaves that to chance. Rather than hardcoding a version in the workflows, which would have to be kept in sync with `Cargo.toml` by hand, the version is resolved from cargo:

```yaml
- name: Resolve wasm-bindgen version
  id: wasm-bindgen
  run: |
    version=$(cargo metadata --format-version 1 --features wasm \
      | jq -r '.packages[] | select(.name=="wasm-bindgen") | .version')
    echo "Using wasm-bindgen $version"
    echo "version=$version" >> "$GITHUB_OUTPUT"
- name: Install wasm-bindgen
  uses: taiki-e/install-action@v2
  with:
    tool: wasm-bindgen@${{ steps.wasm-bindgen.outputs.version }}
```

`Cargo.toml` stays the single source of truth, so bumping the dependency needs no change here. `taiki-e/install-action` has no built-in resolution from the dependency graph, `@version` is the only mechanism it offers, so a step like this is the way to feed it.

Applied to both places that run the cli:

- **`rust.yml`**, the `wasm32-unknown-unknown` test job, via `wasm-bindgen-test-runner`.
- **`publish-wasm.yml`**, which runs `wasm-bindgen --target web` to generate the bindings shipped to npm as `@francisdb/vpin-wasm`. A mismatch here produces a broken published package rather than a failed test run, so it matters more than the test job. That workflow also still used `cargo install wasm-bindgen-cli`, so it picks up the prebuilt binary from #342 at the same time.

## How much does this actually buy

Less than it might look, worth saying out loud. `Cargo.lock` is gitignored (this is a library), so CI resolves `wasm-bindgen` fresh on every run and gets the latest `0.2.x`, while the unpinned install gets the latest cli. They agree today by construction rather than by luck.

What this closes off is the window where they do not: a release where the crate and the cli binary land at different times, or a resolution that picks a version whose cli release is not published yet. It is hardening, not a bug fix.

This does not apply to wasmtime, which is a test runner rather than a dependency, so there is no version to keep in sync and leaving `tool: wasmtime` unpinned is correct.

## Note

`publish-wasm.yml` only runs on `v*` tags, so CI on this PR does not exercise that half. The `rust.yml` half is covered by the `wasm32-unknown-unknown` job.
