### PR TITLE
build(deps): bump wavefront-obj-io from 0.2.0 to 0.3.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -42,6 +42,28 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
 
+  # Verify the declared rust-version stays accurate, dependency bumps or
+  # new language features would otherwise silently raise the real MSRV
+  msrv:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+      - name: Resolve rust-version from Cargo.toml
+        id: msrv
+        run: |
+          version=$(cargo metadata --format-version 1 --no-deps \
+            | jq -r '.packages[] | select(.name=="vpin") | .rust_version')
+          echo "Using Rust $version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+      - name: Install MSRV Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.version }}
+      - uses: Swatinem/rust-cache@v2.9.2
+      - name: Check with MSRV
+        run: cargo check --all-features
+
   wasm32-wasip1:
     runs-on: ubuntu-latest
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ regex = "1.12.2"
 sanitize-filename = "0.6"
 log = "0.4"
 tracing = "0.1"
-wavefront-obj-io = "0.2.0"
+wavefront-obj-io = "0.3.0"
 rayon = { version = "1.11.0", optional = true }
 wasm-bindgen = { version = "0.2.108", optional = true }
 js-sys = { version = "0.3.85", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "vpin"
 version = "0.27.0"
 edition = "2024"
+rust-version = "1.98"
 description = "Rust library for working with Visual Pinball VPX files"
 repository = "https://github.com/francisdb/vpin"
 readme = "README.md"


### PR DESCRIPTION
This drops the itoa dependency but raises the MSRV to 1.98