### PR TITLE
chore: release v0.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.1](https://github.com/francisdb/vpin/compare/v0.28.0...v0.28.1) - 2026-08-27
+
+### Added
+
+- add read_script_file/write_script_file helpers
+
+### Fixed
+
+- extractvbs/importvbs preserve original script bytes
+
 ## [0.28.0](https://github.com/francisdb/vpin/compare/v0.27.0...v0.28.0) - 2026-08-25
 
 ### Other

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vpin"
-version = "0.28.0"
+version = "0.28.1"
 edition = "2024"
 rust-version = "1.98"
 description = "Rust library for working with Visual Pinball VPX files"


### PR DESCRIPTION



## 🤖 New release

* `vpin`: 0.28.0 -> 0.28.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.28.1](https://github.com/francisdb/vpin/compare/v0.28.0...v0.28.1) - 2026-08-27

### Added

- add read_script_file/write_script_file helpers

### Fixed

- extractvbs/importvbs preserve original script bytes
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).